### PR TITLE
Converted all benchmarks

### DIFF
--- a/benchmarks/fptaylor-real2float.fpcore
+++ b/benchmarks/fptaylor-real2float.fpcore
@@ -8,7 +8,7 @@
 (FPCore (x)
  :name "logexp"
  :cite (solovyev-et-al-2015)
- :type binary64
+ :precision binary64
  :pre (<= -8 x 8)
  (let ([e (exp x)])
    (log (+ 1 e))))
@@ -16,7 +16,7 @@
 (FPCore (x r lat lon)
  :name "sphere"
  :cite (solovyev-et-al-2015)
- :type binary64
+ :precision binary64
  :pre (and (<= -10 x 10) (<= 0 r 10)
            (<= -1.570796 lat 1.570796) (<= -3.14159265 lon 3.14159265))
  (let ([sinLat (sin lat)] [cosLon (cos lon)])
@@ -25,7 +25,7 @@
 (FPCore (lat1 lat2  lon1 lon2)
  :name "azimuth"
  :cite (solovyev-et-al-2015)
- :type binary64
+ :precision binary64
  :pre (and (<= 0 lat1 0.4) (<= 0.5 lat2 1)
            (<= 0 lon1 3.14159265) (<= -3.14159265 lon2 -0.5))
  (let ([dLon (- lon2 lon1)])
@@ -42,7 +42,7 @@
 
 (FPCore (x1 x2 x3 x4 x5 x6)
  :name "floudas1"
- :type binary64
+ :precision binary64
  :pre (and (<= 0 x1 6) (<= 0 x2 6) (<= 1 x3 5)
            (<= 0 x4 6) (<= 0 x5 6) (<= 0 x6 10)
            (>= (- (+ (* (- x3 3) (- x3 3)) x4) 4) 0)
@@ -55,7 +55,7 @@
 
 (FPCore (x1 x2)
  :name "floudas2"
- :type binary64
+ :precision binary64
  :pre (and (<= 0 x1 3) (<= 0 x2 4)
            (>= (- (+ (- (* 2 (* (* x1 x1) (* x1 x1))) (* (* 8 (* x1 x1)) x1)) (* (* 8 x1) x1)) x2) 0)
            (>= (- (+ (- (+ (- (* 4 (* (* x1 x1) (* x1 x1))) (* (* 32 (* x1 x1)) x1)) (* (* 88 x1) x1)) (* 96 x1)) 36) x2) 0))
@@ -63,13 +63,13 @@
 
 (FPCore (x1 x2)
  :name "floudas3"
- :type binary64
+ :precision binary64
  :pre (and (<= 0 x1 2) (<= 0 x2 3) (>= (- (+ (* -2 (* (* x1 x2) (* x1 x1))) 2) x2)))
  (+ (- (* -12 x1) (* 7 x2)) (* x2 x2)))
 
 (FPCore (x1 x2 x3)
  :name "hartman3"
- :type binary64
+ :precision binary64
  :pre (and (<= 0 x1 1) (<= 0 x2 1) (<= 0 x3 1))
  (let ([e1 (+ (+ (* 3.0 (* (- x1 0.3689) (- x1 0.3689)))
                  (* 10.0 (* (- x2 0.117) (- x2 0.117))))
@@ -90,7 +90,7 @@
 
 (FPCore (x1 x2 x3 x4 x5 x6)
  :name "hartman6"
- :type binary64
+ :precision binary64
  :pre (and (<= 0 x1 1) (<= 0 x2 1) (<= 0 x3 1) (<= 0 x4 1) (<= 0 x5 1) (<= 0 x6 1))
  (let ([e1
         (+ (+ (+ (+ (+ (* 10.0 (* (- x1 0.1312) (- x1 0.1312))) (* 3.0 (* (- x2 0.1696) (- x2 0.1696))))
@@ -115,14 +115,14 @@
 
 (FPCore (x1 x2 x3 x4 x5 x6)
  :name "kepler0"
- :type binary64
+ :precision binary64
  :pre (and (<= 4 x1 6.36) (<= 4 x2 6.36) (<= 4 x3 6.36) (<= 4 x4 6.36) (<= 4 x5 6.36) (<= 4 x6 6.36))
  (+ (- (- (+ (* x2 x5) (* x3 x6)) (* x2 x3)) (* x5 x6))
     (* x1 (+ (+ (- (+ (+ (- x1) x2) x3) x4) x5) x6))))
 
 (FPCore (x1 x2 x3 x4 x5)
  :name "kepler1"
- :type binary64
+ :precision binary64
  :pre (and (<= 4 x1 6.36) (<= 4 x2 6.36) (<= 4 x3 6.36) (<= 4 x4 6.36))
  (- (- (- (- (+ (+ (* (* x1 x4) (- (+ (+ (- x1) x2) x3) x4))
                    (* x2 (+ (+ (- x1 x2) x3) x4)))
@@ -134,7 +134,7 @@
 
 (FPCore (x1 x2 x3 x4 x5 x6)
  :name "kepler2"
- :type binary64
+ :precision binary64
  :pre (and (<= 4 x1 6.36) (<= 4 x2 6.36) (<= 4 x3 6.36)
            (<= 4 x4 6.36) (<= 4 x5 6.36) (<= 4 x6 6.36))
  (- (- (- (- (+ (+ (* (* x1 x4) (+ (+ (- (+ (+ (- x1) x2) x3) x4) x5) x6))

--- a/benchmarks/fptaylor-tests.fpcore
+++ b/benchmarks/fptaylor-tests.fpcore
@@ -11,7 +11,7 @@
 (FPCore (x y)
   :name "sec4-example"
   :cite (solovyev-et-al-2015)
-  :type binary64
+  :precision binary64
   :pre (and (<= 1.001 x 2) (<= 1.001 y 2))
   (let ([t (* x y)])
     (/ (- t 1) (- (* t t) 1))))
@@ -21,7 +21,7 @@
 
 (FPCore (x0 x1 x2)
   :name "test01_sum3"
-  :type binary32
+  :precision binary32
   :pre (and (< 1 x0 2) (< 1 x1 2) (< 1 x2 2))
   (let ([p0 (- (+ x0 x1) x2)]
         [p1 (- (+ x1 x2) x0)]
@@ -30,7 +30,7 @@
 
 (FPCore (x0 x1 x2 x3 x4 x5 x6 x7 x8)
   :name "test02_sum8"
-  :type binary64
+  :precision binary64
   :pre (and (< 1 x0 2) (< 1 x1 2) (< 1 x2 2)
             (< 1 x3 2) (< 1 x4 2) (< 1 x5 2)
             (< 1 x6 2) (< 1 x7 2))
@@ -38,13 +38,13 @@
 
 (FPCore (x y)
   :name "test03_nonlin2"
-  :type binary64
+  :precision binary64
   :pre (and (< 0 x 1) (< -1 y -0.1))
   (/ (+ x y) (- x y)))
 
 (FPCore (m0 m1 m2 w0 w1 w2 a0 a1 a2)
   :name "test04_dqmom9"
-  :type binary64
+  :precision binary64
   :pre (and (< -1 m0 1) (< -1 m1 1) (< -1 m2 1)
             (< 0.00001 w0 1) (< 0.00001 w1 1) (< 0.00001 w2 1)
             (< 0.00001 a0 1) (< 0.00001 a1 1) (< 0.00001 a2 1))
@@ -55,25 +55,25 @@
 
 (FPCore (x)
   :name "test05_nonlin1, r4"
-  :type binary64
+  :precision binary64
   :pre (< 1.00001 x 2)
   (let ([r1 (- x 1)] [r2 (* x x)])
     (/ r1 (- r2 1))))
 
 (FPCore (x)
   :name "test05_nonlin1, test2"
-  :type binary64
+  :precision binary64
   :pre (< 1.00001 x 2)
   (/ 1 (+ x 1)))
 
 (FPCore (x0 x1 x2 x3)
   :name "test06_sums4, sum1"
-  :type binary32
+  :precision binary32
   :pre (and (< -1e-5 x0 1.00001) (< 0 x1 1) (< 0 x2 1) (< 0 x3 1))
   (+ (+ (+ x0 x1) x2) x3))
 
 (FPCore (x0 x1 x2 x3)
   :name "test06_sums4, sum2"
-  :type binary32
+  :precision binary32
   :pre (and (< -1e-5 x0 1.00001) (< 0 x1 1) (< 0 x2 1) (< 0 x3 1))
   (+ (+ x0 x1) (+ x2 x3)))

--- a/benchmarks/rosa.fpcore
+++ b/benchmarks/rosa.fpcore
@@ -32,7 +32,7 @@
   :name "doppler3"
   :cite (darulova-kuncak-2014)
   :fpbench-domain science
-  :type binary64
+  :precision binary64
   :pre (and (<= -30 u 120) (<= 320 v 20300) (<= -50 T 30))
   (let ([t1 (+ 331.4 (* 0.6 T))])
     (/ (* (- t1) v) (* (+ t1 u) (+ t1 u)))))
@@ -41,7 +41,7 @@
   :name "rigidBody1"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain science
-  :type binary64
+  :precision binary64
   :pre (and (<= -15 x1 15) (<= -15 x2 15) (<= -15 x3 15))
   (- (- (- (- (* x1 x2)) (* (* 2 x2) x3)) x1) x3))
 
@@ -49,7 +49,7 @@
   :name "rigidBody2"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain science
-  :type binary64
+  :precision binary64
   :pre (and (<= -15 x1 15) (<= -15 x2 15) (<= -15 x3 15))
   (- (+ (- (+ (* (* (* 2 x1) x2) x3) (* (* 3 x3) x3))
            (* (* (* x2 x1) x2) x3)) (* (* 3 x3) x3))
@@ -59,7 +59,7 @@
   :name "jetEngine"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain controls
-  :type binary64
+  :precision binary64
   :pre (and (<= -5 x1 5) (<= -20 x2 5))
   (let ([t (- (+ (* (* 3 x1) x1) (* 2 x2)) x1)]
         [t* (- (- (* (* 3 x1) x1) (* 2 x2)) x1)]
@@ -80,7 +80,7 @@
   :name "turbine1"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain controls
-  :type binary64
+  :precision binary64
   :pre (and (<= -4.5 v -0.3) (<= 0.4 w 0.9) (<= 3.8 r 7.8))
   (- (- (+ 3 (/ 2 (* r r))) (/ (* (* 0.125 (- 3 (* 2 v))) (* (* (* w w) r) r)) (- 1 v))) 4.5))
 
@@ -88,7 +88,7 @@
   :name "turbine2"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain controls
-  :type binary64
+  :precision binary64
   :pre (and (<= -4.5 v -0.3) (<= 0.4 w 0.9) (<= 3.8 r 7.8))
   (- (- (* 6 v) (/ (* (* 0.5 v) (* (* (* w w) r) r)) (- 1 v))) 2.5))
 
@@ -96,7 +96,7 @@
   :name "turbine3"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain controls
-  :type binary64
+  :precision binary64
   :pre (and (<= -4.5 v -0.3) (<= 0.4 w 0.9) (<= 3.8 r 7.8))
   (- (- (- 3 (/ 2 (* r r)))
         (/ (* (* 0.125 (+ 1 (* 2 v))) (* (* (* w w) r) r)) (- 1 v)))
@@ -106,7 +106,7 @@
   :name "verhulst"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain science
-  :type binary64
+  :precision binary64
   :pre (<= 0.1 x 0.3)
   (let ([r 4.0] [K 1.11])
     (/ (* r x) (+ 1 (/ x K)))))
@@ -115,7 +115,7 @@
   :name "predatorPrey"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain science
-  :type binary64
+  :precision binary64
   :pre (<= 0.1 x 0.3)
   (let ([r 4.0] [K 1.11])
     (/ (* (* r x) x) (+ 1 (* (/ x K) (/ x K))))))
@@ -124,7 +124,7 @@
   :name "carbonGas"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain science
-  :type binary64
+  :precision binary64
   :pre (<= 0.1 v 0.5)
   (let ([p 3.5e7] [a 0.401] [b 42.7e-6] [t 300] [n 1000] [k 1.3806503e-23])
     (- (* (+ p (* (* a (/ n v)) (/ n v))) (- v (* n b))) (* (* k n) t))))
@@ -133,7 +133,7 @@
   :name "sine"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain mathematics
-  :type binary64
+  :precision binary64
   :rosa-post (=> res (< -1 res 1))
   :rosa-ensuring 1e-14
   :pre (< -1.57079632679 x 1.57079632679)
@@ -153,7 +153,7 @@
   :name "sineOrder3"
   :cite (darulova-kuncak-2014 solovyev-et-al-2015)
   :fpbench-domain mathematics
-  :type binary64
+  :precision binary64
   :pre (< -2 x 2)
   :rosa-post (=> res (< -1 res 1))
   :rosa-ensuring 1e-14

--- a/benchmarks/salsa.fpcore
+++ b/benchmarks/salsa.fpcore
@@ -10,7 +10,7 @@
  (damouche-martel-chapoutot-fmics15)
  :fpbench-domain
  controls
- :type
+ :precision
  binary32
  :pre
  (and (< 0.05 sl (* 2 PI)) (< 0.05 sr (* 2 PI)))
@@ -116,7 +116,7 @@
  (damouche-martel-chapoutot-fmics15)
  :fpbench-domain
  controls
- :type
+ :precision
  binary32
  :pre
  (and (< 0.05 sl (* 2 PI)) (< 0.05 sr (* 2 PI)))
@@ -222,7 +222,7 @@
  (damouche-martel-chapoutot-nsv14)
  :fpbench-domain
  controls
- :type
+ :precision
  binary64
  :pre
  (and (< -10.0 m 10.0) (< -10.0 c 10.0))
@@ -258,7 +258,7 @@
  (damouch-martel-chapoutot-fmics15)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 0 y_n 100) (< 1e-05 h 0.1) (< 50 c 200))
@@ -324,7 +324,7 @@
  (damouch-martel-chapoutot-fmics15)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 0 y_n 100) (< 1e-05 h 0.1) (< 50 c 200))
@@ -390,7 +390,7 @@
  (feron-ieee10)
  :fpbench-domain
  controls
- :type
+ :precision
  binary32
  :pre
  (and (< 0 yd 50) (< 0 y 50))
@@ -470,7 +470,7 @@
  (damouche-martel-chapoutot-cf15)
  :fpbench-domain
  controls
- :type
+ :precision
  binary32
  :example
  ((Mf 150000.0) (A 140.0))
@@ -606,7 +606,7 @@
  (damouche-martel-chapoutot-cf15)
  :fpbench-domain
  controls
- :type
+ :precision
  binary32
  :example
  ((Mf 150000.0) (A 140.0))
@@ -742,7 +742,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :example
  ((a11 0.61)
@@ -805,7 +805,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :example
  ((a11 0.61)
@@ -873,7 +873,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :example
  ((a11 0.61)
@@ -936,7 +936,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :example
  ((a11 0.61)
@@ -999,7 +999,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 0 x0 3)
@@ -1070,7 +1070,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 0 x0 3)
@@ -1141,7 +1141,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 0 x0 3)
@@ -1233,7 +1233,7 @@
  (atkinson-1989)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 0 x0 3)
@@ -1304,7 +1304,7 @@
  (golub-vanloan-1996)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 150 d 200)
@@ -1367,7 +1367,7 @@
  (golub-vanloan-1996)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 150 d 200)
@@ -1430,7 +1430,7 @@
  (golub-vanloan-1996)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 150 d 200)
@@ -1494,7 +1494,7 @@
  (golub-vanloan-1996)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (< 150 d 200)
@@ -1557,7 +1557,7 @@
  (abdelmalek-bit71 golub-vanloan-1996 hernandez-roman-tomas-vidal-tr07)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 1.0 Q11 (/ 1 7)) (< 1 Q22 (/ 1 25)))
@@ -1660,7 +1660,7 @@
  (abdelmalek-bit71 golub-vanloan-1996 hernandez-roman-tomas-vidal-tr07)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 1.0 Q11 (/ 1 7)) (< 1 Q22 (/ 1 25)))
@@ -1763,7 +1763,7 @@
  (abdelmalek-bit71 golub-vanloan-1996 hernandez-roman-tomas-vidal-tr07)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 1.0 Q11 (/ 1 7)) (< 1 Q22 (/ 1 25)))
@@ -1866,7 +1866,7 @@
  (abdelmalek-bit71 golub-vanloan-1996 hernandez-roman-tomas-vidal-tr07)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 1.0 Q11 (/ 1 7)) (< 1 Q22 (/ 1 25)))
@@ -1969,7 +1969,7 @@
  (abdelmalek-bit71 golub-vanloan-1996 hernandez-roman-tomas-vidal-tr07)
  :fpbench-domain
  mathematics
- :type
+ :precision
  binary32
  :pre
  (and (< 1.0 Q11 (/ 1 7)) (< 1 Q22 (/ 1 25)))

--- a/benchmarks/salsa.fpimp
+++ b/benchmarks/salsa.fpimp
@@ -56,7 +56,7 @@ Inputs: Speed `sl`, `sr` of the left and right wheel, in rad/s."
 Inputs: Measure `m`; gains `kp`, `ki`, `kd`; setpoint `c`"
  :cite (damouche-martel-chapoutot-nsv14 damouche-martel-chapoutot-fmics15)
  :fpbench-domain controls
- :type binary64
+ :precision binary64
  :pre (and (< -10.0 m 10.0) (< -10.0 c 10.0))
  :example ([m -5.0] [kp 9.4514] [ki 0.69006] [kd 2.8454])
  [= t 0.0]
@@ -82,7 +82,7 @@ Inputs: Measure `m`; gains `kp`, `ki`, `kd`; setpoint `c`"
 Inputs: Step size `h`; initial condition `y_n*`; paramter `c`"
  :cite (damouch-martel-chapoutot-fmics15)
  :fpbench-domain mathematics
- :type binary32
+ :precision binary32
  :pre (and (< 0 y_n 100) (< 10e-6 h 0.1) (< 50 c 200))
  :example ([h 0.1] [y_n* 10.1] [c 100.1])
  [= sixieme (/ 1 6)]
@@ -111,7 +111,7 @@ Inputs: Step size `h`; initial condition `y_n*`; paramter `c`"
 Inputs: Initial position `y`; desired position `yd`"
  :cite (feron-ieee10 damouche-martel-chapoutot-fmics15)
  :fpbench-domain controls
- :type binary32
+ :precision binary32
  :pre (and (< 0 yd 50) (< 0 y 50))
  :example ([y 2.5] [yd 5.0])
  [= i 0.0]
@@ -167,7 +167,7 @@ Inputs: Initial position `y`; desired position `yd`"
 Inputs: Mass `Mf`; acceleration `A`"
  :cite (damouche-martel-chapoutot-cf15)
  :fpbench-domain controls
- :type binary32
+ :precision binary32
  :example ([Mf 150000.0] [A 140.0])
  [= R 6400.0e3]
  [= G 6.67428e-11]
@@ -235,7 +235,7 @@ Inputs: Mass `Mf`; acceleration `A`"
 Inputs: Array entries `aij`; vector entries `bi`"
  :cite (atkinson-1989)
  :fpbench-domain mathematics
- :type binary32
+ :precision binary32
  :example ([a11 0.61] [a22 0.62] [a33 0.6006] [a44 0.601]
                   [b1 0.5] [b2 (/ 1.0 3.0)] [b3 0.25] [b4 (/ 1.0 5.0)])
  [= i 0.0]
@@ -269,7 +269,7 @@ Inputs: Array entries `aij`; vector entries `bi`"
 Inputs: Initial guess `x0`"
  :cite (atkinson-1989)
  :fpbench-domain mathematics
- :type binary32
+ :precision binary32
  :pre (< 0 x0 3)
  :example ([x0 0.0])
  [= eps 0.0005]
@@ -292,7 +292,7 @@ Inputs: Initial guess `x0`"
 Inputs: Matrix `aij`; initial guess `vi` with one nonzero element"
  :cite (golub-vanloan-1996)
  :fpbench-domain mathematics
- :type binary32
+ :precision binary32
  :pre (< 150 d 200)
  :example ([a11 150.0] [a12  0.01] [a13  0.01] [a14  0.01]
                   [a21  0.01] [a22 150.0] [a23  0.01] [a24  0.01]
@@ -322,7 +322,7 @@ Inputs: Matrix `aij`; initial guess `vi` with one nonzero element"
 Inputs: Vectors `Qij`"
  :cite (abdelmalek-bit71 golub-vanloan-1996 hernandez-roman-tomas-vidal-tr07)
  :fpbench-domain mathematics
- :type binary32
+ :precision binary32
  :pre (and (< 1.0 Q11 (/ 1 7)) (< 1 Q22 (/ 1 25)))
  :example ([Q11 (/ 1 63)] [Q12 0] [Q13 0]
                   [Q21 0] [Q22 (/ 1 225)] [Q23 0]

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -77,7 +77,7 @@
            (for ([prog (in-port read p)])
              (match-define (list 'FPCore (list vars ...) props* ... body) prog)
              (define-values (_ props) (parse-properties props*))
-             (define type (dict-ref props ':type 'binary64))
+             (define type (dict-ref props ':precision 'binary64))
              (define exec-file (compile->c prog (test-file) #:type type))
              (define timeout 0)
              (define results

--- a/tools/core2c.rkt
+++ b/tools/core2c.rkt
@@ -127,7 +127,7 @@
 (define (compile-program prog #:name name)
   (match-define (list 'FPCore (list args ...) props ... body) prog)
   (define-values (_ properties) (parse-properties props))
-  (define type (dict-ref properties ':type 'binary64))
+  (define type (dict-ref properties ':precision 'binary64))
 
   (define arg-strings
     (for/list ([var args])

--- a/tools/fpcore.rkt
+++ b/tools/fpcore.rkt
@@ -118,7 +118,7 @@
   (match-define `(FPCore (,vars ...) ,props* ... ,body) prog)
   (define-values (_ props) (parse-properties props*))
   (define evaltor
-    (match (dict-ref props ':type 'binary64)
+    (match (dict-ref props ':precision 'binary64)
       ['binary64 racket-double-evaluator]
       ['binary32 racket-single-evaluator]))
   ((eval-expr evaltor) body (map cons vars (map (evaluator-real evaltor) vals))))

--- a/tools/fpimp.rkt
+++ b/tools/fpimp.rkt
@@ -56,7 +56,7 @@
   (match-define `(FPImp (,vars ...) ,props&body ...) prog)
   (define-values (body props) (parse-properties props&body))
   (define evaltor
-    (match (dict-ref props ':type 'binary64)
+    (match (dict-ref props ':precision 'binary64)
       ['binary64 racket-double-evaluator]
       ['binary32 racket-single-evaluator]))
   ((eval-stmts (eval-expr evaltor)) body (map cons vars (map (evaluator-real evaltor) vals))))

--- a/tools/sample-accuracy.rkt
+++ b/tools/sample-accuracy.rkt
@@ -146,7 +146,7 @@
 (define (average-error expr #:measure [measurefn bits-error] #:points [N 8000])
   (match-define (list 'FPCore (list args ...) props ... body) expr)
   (define-values (_ properties) (parse-properties props))
-  (define type (dict-ref properties ':type 'binary64))
+  (define type (dict-ref properties ':precision 'binary64))
   (define pre (dict-ref properties ':pre 'TRUE))
 
   (define-values (points exacts approxs)


### PR DESCRIPTION
The "Metadata" standard says that the precision should be specified in the `:precision` field, yet the benchmarks use `:type`. This changes all of the benchmarks from `:type` to `:precision`.