### PR TITLE
Make core2scala detect exact integer numbers

### DIFF
--- a/tools/core2scala.rkt
+++ b/tools/core2scala.rkt
@@ -120,7 +120,9 @@
     [(? symbol?)
      (fix-name (dict-ref names expr expr))]
     [(? number?)
-     (format "~a" (real->double-flonum expr))]))
+     (if (= expr (round expr))
+         (format "~a" (round expr))
+         (format "~a" (real->double-flonum expr)))]))
 
 (define (compile-program prog index)
   (match-define (list 'FPCore (list args ...) props ... body) prog)


### PR DESCRIPTION
I added a simple check to the translation of numbers, that uses the exact integer number, in case a number like 3.0 appears in an FPCore file. Instead of producing the scala 3.0, it will now produce a 3 which the Scala compiler can parse it into an integer instead of a floating-point constant.