### PR TITLE
Make daisy_herbie script machine-independent

### DIFF
--- a/tools/daisy_herbie.py
+++ b/tools/daisy_herbie.py
@@ -35,8 +35,12 @@ def runHerbie (benchmark) :
         ["racket", HERBIE_DIR + "/src/herbie.rkt", "improve", "-", "-"],
         stdout=subprocess.PIPE,
         input=benchmark, universal_newlines=True)
+    try:
+        result = out.stdout.split("\n")[-2]
+    except IndexError:
+        result = "ERROR"
     dt = time.time() - start
-    return dt, out.stdout.split("\n")[-2], out.returncode
+    return dt, result, out.returncode
 
 # Run FPCore2Scala converter on file inFname, write output to file outFname
 def runConverter (benchmark):
@@ -69,7 +73,10 @@ def runDaisy (benchmark, certificates=True):
     return dt, "FAILED", out.returncode
 
 def runTest(in_fpcore):
-    name = in_fpcore.split(":name")[1].split('"')[1]
+    if ":name" in in_fpcore:
+        name = in_fpcore.split(":name")[1].split('"')[1]
+    else:
+        name = in_fpcore
     yield name
 
     (timeHerbie, out_fpcore, exitcode) = runHerbie (in_fpcore)
@@ -118,6 +125,7 @@ if __name__ == "__main__":
 
     HERBIE_DIR = args.herbie_dir
     DAISY_DIR = args.daisy_dir
-    FPBENCH_DIR = os.path.dirname(dir_type(os.path.dirname(__file__)))
+    current_dir = os.path.dirname(__file__)
+    FPBENCH_DIR = os.path.dirname(dir_type(current_dir or "."))
 
     main()

--- a/tools/daisy_herbie.py
+++ b/tools/daisy_herbie.py
@@ -65,12 +65,16 @@ def runDaisy (benchmark, certificates=True):
 
     if out.returncode:
         print(out.stdout, file=sys.stderr)
+        print(out.stderr, file=sys.stderr)
+        return dt, "FAILED", out.returncode
 
     for line in out.stdout.split("\n"):
         if "abs-error" in line:
             return dt, float(line.split(",")[0].split(":")[1]), out.returncode
-
-    return dt, "FAILED", out.returncode
+    else:
+        print(out.stderr, file=sys.stderr)
+        print(out.stdout, file=sys.stderr)
+        return dt, "FAILED", out.returncode
 
 def runTest(in_fpcore):
     if ":name" in in_fpcore:
@@ -80,20 +84,30 @@ def runTest(in_fpcore):
     yield name
 
     (timeHerbie, out_fpcore, exitcode) = runHerbie (in_fpcore)
-    if not exitcode == 0: return
+    if not exitcode == 0:
+        print("HERBIE ERROR ON: ", in_fpcore, file=sys.stderr)
+        return
     yield timeHerbie
 
     (in_scala, exitcode) = runConverter (in_fpcore)
-    if not exitcode == 0: return
+    if not exitcode == 0:
+        print("CONVERTER ERROR ON: ", in_fpcore, file=sys.stderr)
+        return
 
     (out_scala, exitcode) = runConverter (out_fpcore)
-    if not exitcode == 0: return
+    if not exitcode == 0:
+        print("CONVERTER ERROR ON: ", out_fpcore, file=sys.stderr)
+        return
 
     (timeInDaisy, errInDaisy, exitCode) = runDaisy (in_scala)
-    if not exitcode == 0: return
+    if not exitcode == 0:
+        print("DAISY ERROR ON: ", in_scala, file=sys.stderr)
+        return
 
     (timeOutDaisy, errOutDaisy, exitCode) = runDaisy (out_scala)
-    if not exitcode == 0: return
+    if not exitcode == 0:
+        print("DAISY ERROR ON: ", out_scala, file=sys.stderr)
+        return
 
     yield from [timeInDaisy, timeOutDaisy, errInDaisy, errOutDaisy]
 

--- a/tools/daisy_herbie.py
+++ b/tools/daisy_herbie.py
@@ -23,7 +23,7 @@ def getFiles():
 def runFilter (benchmarks, args) :
     out = subprocess.run(
         ["racket", FPBENCH_DIR + "/tools/filter.rkt"] + args,
-        input="\n\n".join(benchmarks), encoding="utf-8",
+        input="\n\n".join(benchmarks), universal_newlines=True,
         stdout=subprocess.PIPE)
     return out.stdout.split("\n\n")
 
@@ -34,7 +34,7 @@ def runHerbie (benchmark) :
     out = subprocess.run(
         ["racket", HERBIE_DIR + "/src/herbie.rkt", "improve", "-", "-"],
         stdout=subprocess.PIPE,
-        input=benchmark, encoding="utf-8")
+        input=benchmark, universal_newlines=True)
     dt = time.time() - start
     return dt, out.stdout.split("\n")[-2], out.returncode
 
@@ -42,7 +42,7 @@ def runHerbie (benchmark) :
 def runConverter (benchmark):
     out = subprocess.run(
         ["racket", FPBENCH_DIR + "/tools/core2scala.rkt"],
-        input=benchmark, encoding="utf-8",
+        input=benchmark, universal_newlines=True,
         stdout=subprocess.PIPE)
     return out.stdout, out.returncode
 
@@ -55,7 +55,7 @@ def runDaisy (benchmark, certificates=True):
         f.flush()
         out = subprocess.run(
             ["./daisy", f.name],
-            stdout=subprocess.PIPE, encoding="utf-8")
+            stdout=subprocess.PIPE, universal_newlines=True)
     dt = time.time() - start
     os.chdir(cwd)
 

--- a/tools/daisy_herbie.py
+++ b/tools/daisy_herbie.py
@@ -116,7 +116,7 @@ def runTests(benchmarks):
     for benchmark in benchmarks:
         first = True
         for field in runTest(benchmark):
-            text = '"{}"'.format(field.replace("\"", "\\\"")) if isinstance(field, str) else "{:.2f}".format(field)
+            text = '"{}"'.format(field.replace("\"", "\\\"")) if isinstance(field, str) else "{:.2g}".format(field)
             print(text if first else ", " + text, end="")
             sys.stdout.flush()
             first = False

--- a/tools/daisy_herbie.py
+++ b/tools/daisy_herbie.py
@@ -1,169 +1,123 @@
 #!/usr/bin/env python3
 
-import sys, os, subprocess
-import time
+import sys, os, subprocess, tempfile, time
 
-HERBIE_DIR="/home/hbecker/Git_Repos/herbie"
-FPBENCH_DIR="/home/hbecker/Git_Repos/FPBench"
-DAISY_DIR="/home/hbecker/Git_Repos/daisy"
+# Set by running the script
+HERBIE_DIR = DAISY_DIR = FPBENCH_DIR = None
 
-# EXPERIMENTS_DIR="/home/hbecker/Git_Repos/daisy/testcases/cpp2018"
-EXPERIMENTS_DIR="/home/hbecker/Git_Repos/FPBench/benchmarks"
-
+def dir_type(path):
+    if not os.path.exists(path):
+        raise argparse.ArgumentTypeError("Path does not exist", path)
+    if not os.path.isdir(path):
+        raise argparse.ArgumentTypeError("Path is not a directory", path)
+    return os.path.realpath(os.path.expanduser(path))
 
 def getFiles():
-    fileObj = open(EXPERIMENTS_DIR + "/daisy_herbie.fpcore", "r")
-    fileContent = fileObj.read()
-    benchmarks = fileContent.split("\n\n")
-    return benchmarks
-    # fileC = ""
-    # fileIndex = []
-    # for dirname, subdirs, files in os.walk(EXPERIMENTS_DIR):
-    #     for file in files:
-    #         suffix=file.split(".")[1]
-    #         if suffix == "fpcore":
-    #             filep = open (dirname + "/" + file, "r")
-    #             for line in filep:
-    #                 fileC = fileC + line
-    #             fileIndex.append (dirname + "/" + file)
-    return [] #fileIndex
+    for dirname, subdirs, files in os.walk(FPBENCH_DIR + "/benchmarks"):
+        for file in files:
+            if not file.endswith(".fpcore"): continue
 
-def runFilter (fileC) :
-    infile =open("/tmp/filter_in.txt", "w")
-    infile.write(fileC)
-    infile.flush()
-    infile.close()
-    infile=open("/tmp/filter_in.txt", "r")
-    progRet = subprocess.Popen(["racket",
-                                FPBENCH_DIR + "/tools/filter.rkt",
-                                "operations",
-                                "+ - / '*'"],
-                               stdout=subprocess.PIPE,
-                               stdin=infile)
-    progRet.wait()
-    print(progRet.stdout.read().decode())
+            with open(dirname + "/" + file, "r") as f:
+                yield from filter(lambda x: x, f.read().split("\n\n"))
+
+def runFilter (benchmarks, args) :
+    out = subprocess.run(
+        ["racket", FPBENCH_DIR + "/tools/filter.rkt"] + args,
+        input="\n\n".join(benchmarks), encoding="utf-8",
+        stdout=subprocess.PIPE)
+    return out.stdout.split("\n\n")
 
 # run Herbies improvement phase on inFname file,
 # produce resulting fpcore file in outFname
-def runHerbie (inFname, outFname) :
+def runHerbie (benchmark) :
     start = time.time()
-    resultText=""
-    progRet = subprocess.Popen (["racket",
-                                HERBIE_DIR + "/src/herbie.rkt",
-                                "improve",
-                                inFname,
-                                outFname],
-                                stdout=subprocess.PIPE)
-    progRet.wait()
-    end = time.time()
-    stdoutBinary = progRet.stdout.read()
-    stdoutText = stdoutBinary.decode()
-    print(stdoutText)
-    return (end-start, progRet.returncode)
+    out = subprocess.run(
+        ["racket", HERBIE_DIR + "/src/herbie.rkt", "improve", "-", "-"],
+        stdout=subprocess.PIPE,
+        input=benchmark, encoding="utf-8")
+    dt = time.time() - start
+    return dt, out.stdout.split("\n")[-2], out.returncode
 
 # Run FPCore2Scala converter on file inFname, write output to file outFname
-def runConverter (inFname, outFname):
-    infile = open (inFname, "r")
-    outfile = open (outFname, "w")
-    proc = subprocess.Popen (
-        ["racket",
-         FPBENCH_DIR + "/tools/core2scala.rkt"],
-        stdin=infile,
-        stdout=outfile)
-    proc.wait()
-    outfile.flush()
-    infile.close()
-    outfile.close()
-    return proc.returncode
+def runConverter (benchmark):
+    out = subprocess.run(
+        ["racket", FPBENCH_DIR + "/tools/core2scala.rkt"],
+        input=benchmark, encoding="utf-8",
+        stdout=subprocess.PIPE)
+    return out.stdout, out.returncode
 
-def runDaisy (inFname,certificates=True):
+def runDaisy (benchmark, certificates=True):
     cwd = os.getcwd()
     os.chdir(DAISY_DIR)
-    outfile = open ("/tmp/daisy_res.txt","w")
-    errfile = open ("/tmp/daisy_err.txt", "w")
     start = time.time()
-    proc = subprocess.Popen (["./daisy",
-                              inFname],
-                             stdout= outfile,
-                             stderr = errfile)
-    proc.wait()
-    end = time.time()
-
-    outfile.flush()
-    errfile.flush()
-    outfile.close()
-    errfile.close()
+    with tempfile.NamedTemporaryFile(suffix=".scala") as f:
+        f.write(benchmark.encode("utf-8"))
+        f.flush()
+        out = subprocess.run(
+            ["./daisy", f.name],
+            stdout=subprocess.PIPE, encoding="utf-8")
+    dt = time.time() - start
     os.chdir(cwd)
 
-    runTime = end - start
+    if out.returncode:
+        print(out.stdout, file=sys.stderr)
 
-    resFile = open ("/tmp/daisy_res.txt", "r")
-    for line in resFile:
+    for line in out.stdout.split("\n"):
         if "abs-error" in line:
-            return (runTime,line.split(",")[0].split(":")[1])
+            return dt, float(line.split(",")[0].split(":")[1]), out.returncode
 
-    return (runTime, "FAILED")
+    return dt, "FAILED", out.returncode
 
-# test runner wrapper function,
-# iterate over all files in given list, run the evaluation pipeline
-# store all results in output file as csv table, to parse externally
-def runTests (benchmarks,tableName):
-    table = open(tableName, "w")
-    table.write("Benchmark name, Herbie , Daisy (src), Daisy (res), roundoff err (src), roundoff err (res)")
-    table.write("\n")
+def runTest(in_fpcore):
+    name = in_fpcore.split(":name")[1].split('"')[1]
+    yield name
+
+    (timeHerbie, out_fpcore, exitcode) = runHerbie (in_fpcore)
+    if not exitcode == 0: return
+    yield timeHerbie
+
+    (in_scala, exitcode) = runConverter (in_fpcore)
+    if not exitcode == 0: return
+
+    (out_scala, exitcode) = runConverter (out_fpcore)
+    if not exitcode == 0: return
+
+    (timeInDaisy, errInDaisy, exitCode) = runDaisy (in_scala)
+    if not exitcode == 0: return
+
+    (timeOutDaisy, errOutDaisy, exitCode) = runDaisy (out_scala)
+    if not exitcode == 0: return
+
+    yield from [timeInDaisy, timeOutDaisy, errInDaisy, errOutDaisy]
+
+def runTests(benchmarks):
+    print("Benchmark name, Herbie, Daisy (src), Daisy (res), roundoff err (src), roundoff err (res)")
     for benchmark in benchmarks:
-        if not benchmark:
-            continue
-        afterName=benchmark.split(":name")[1]
-        theName=benchmark.split('"')[1]
-        table.write(theName + ", ")
-        input=open("/tmp/herbie_in.fpcore","w")
-        input.write(benchmark)
-        input.close()
-        (timeHerbie, exitcode) = runHerbie ("/tmp/herbie_in.fpcore", "/tmp/herbie_out.fpcore")
-        if not exitcode == 0:
-            table.write("Herbie FAILED , FAILED, FAILED, FAILED, FAILED\n")
-            continue
-        table.write (str(round(timeHerbie,2)) + " ,")
-        retInConv = runConverter ("/tmp/herbie_in.fpcore", "/tmp/herbie_in.scala")
-        if not retInConv == 0:
-            table.write("InputConversion Failed, InputConversion Failed, InputConversion Failed, InputConversion Failed\n")
-            continue
-        retOutConv = runConverter("/tmp/herbie_out.fpcore", "/tmp/herbie_out.scala")
-        (timeInDaisy, errSrcDaisy) = runDaisy ("/tmp/herbie_in.scala")
-        if not retOutConv == 0:
-            table.write(str(round(timeInDaisy,2)) + ", OutputConversion Failed, " + errSrcDaisy + ", OutputConversion Failed\n")
-            continue
-        (timeOutDaisy, errOutDaisy) = runDaisy ("/tmp/herbie_out.scala")
-        table.write(str(round(timeInDaisy,2)) + ", " + str(round(timeOutDaisy,2)) + ", " + errSrcDaisy +", " + errOutDaisy + "\n")
-    table.close()
-    return
-    #for file in files:
-    #theName = getProperName("/home/hbecker/Git_Repos/FPBench/benchmarks/doppler1.fpcore")
-    #table.write(theName)
-    #timeHerbie = runHerbie ("/home/hbecker/Git_Repos/FPBench/benchmarks/doppler1.fpcore",
-    #"/tmp/out_herbie1.fpcore")
-    #runConverter ("/home/hbecker/Git_Repos/FPBench/benchmarks/herbie.fpcore",
-    #"/tmp/in_herbie.scala")
-    # runConverter("/tmp/out_herbie1.fpcore", "/tmp/out_herbie.scala")
-    # (timeInDaisy, errSrcDaisy) = runDaisy ("/tmp/in_herbie.scala")
-    # (timeOutDaisy, errOutDaisy) = runDaisy ("/tmp/out_herbie.scala")
-    # table.write(str(timeInDaisy) + ", " + str(timeOutDaisy) + ", " + errSrcDaisy + errOutDaisy)
-    # table.close()
-    return
+        first = True
+        for field in runTest(benchmark):
+            text = '"{}"'.format(field.replace("\"", "\\\"")) if isinstance(field, str) else "{:.2f}".format(field)
+            print(text if first else ", " + text, end="")
+            sys.stdout.flush()
+            first = False
+        print()
 
-def main(argv):
-    print ("Starting to get files")
-    benchmarks=getFiles()
-    runTests(benchmarks, "/home/hbecker/Documents/herbie_daisy_prelim_results.csv")
-    return 0
-
-### UTILITY functions
-def getProperName (fNameWithPath):
-    fnameWithoutPathList = fNameWithPath.split("/")
-    fNameNoPath = fnameWithoutPathList[len(fnameWithoutPathList)-1]
-    return (fNameNoPath.split(".")[0]) #remove file extension
-
+def main():
+    benchmarks = list(getFiles())
+    print ("Found {} total benchmarks".format(len(benchmarks)), file=sys.stderr)
+    benchmarks = runFilter(benchmarks, ["operations", "+", "-", "/", "*"])
+    benchmarks = runFilter(benchmarks, ["pre"])
+    print ("Filtered down to {} benchmarks".format(len(benchmarks)), file=sys.stderr)
+    runTests(benchmarks)
 
 if __name__ == "__main__":
-    main(sys.argv)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("herbie_dir", help="The directory of the Herbie source code", type=dir_type)
+    parser.add_argument("daisy_dir", help="The directory of the Daisy source code", type=dir_type)
+    args = parser.parse_args()
+
+    HERBIE_DIR = args.herbie_dir
+    DAISY_DIR = args.daisy_dir
+    FPBENCH_DIR = os.path.dirname(dir_type(os.path.dirname(__file__)))
+
+    main()


### PR DESCRIPTION
Machine independence required many changes:

 - Take Herbie and Daisy paths as arguments
 - Compute FPBench path on its own
 - Avoid using files as much as possible; used only for Daisy
 - Output goes to standard output and standard error

There were also large style changes made:

 - `subprocess.run` instead of the more complex `Popen`
 - `with` to encapsulate file use with automatic closing
 - Streams to split generation and output