### PR TITLE
Add FPCore to SMT-LIB compiler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,18 @@ notifications:
 language: node_js
 node_js:
   - "6.11.4"
+env:
+  global:
+    - RACKET_DIR=~/racket
+    - RACKET_VERSION="7.0"
+    - Z3_VERSION="4.7.1"
+    - Z3_DISTRIB="z3-4.7.1-x64-ubuntu-14.04"
 before_install:
   - npm install mathjs@4.2.1
-  - export RACKET_DIR=~/racket
-  - export RACKET_VERSION="6.9"
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
-  - export PATH="${RACKET_DIR}/bin:${PATH}"
+  - curl -L -O https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/${Z3_DISTRIB}.zip
+  - unzip ${Z3_DISTRIB}.zip
+  - export PATH="${RACKET_DIR}/bin:${PWD}/${Z3_DISTRIB}/bin:${PATH}"
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ test:
 	racket infra/test-core2js.rkt -o ./tmp.js benchmarks/*.fpcore
 	racket infra/test-core2c.rkt benchmarks/*.fpcore
 	racket infra/test-imp2core.rkt benchmarks/*.fpimp
+	cat benchmarks/*.fpcore | racket tools/filter.rkt operators "+" "-" "*" "/" fabs fma sqrt remainder fmax fmin trunc round nearbyint "<" ">" "<=" ">=" "==" "!=" and or not isfinite isinf isnan isnormal signbit | racket infra/test-core2smtlib2.rkt
 
 %.fpcore: %.fpimp
 	printf ";; -*- mode: scheme -*-\n\n" > $@

--- a/infra/test-common.rkt
+++ b/infra/test-common.rkt
@@ -1,0 +1,35 @@
+#lang racket
+
+(require  "../tools/fpcore.rkt" "../tools/fpimp.rkt")
+
+(provide eval-fuel-expr eval-fuel-stmt sample-double sample-single)
+
+(define ((eval-fuel-expr evaltor fuel [default #f]) expr ctx)
+  (let/ec k
+    (let eval ([expr expr] [ctx ctx] [fuel fuel])
+      (if (<= fuel 0)
+          (k default)
+          ((eval-expr* evaltor (λ (expr ctx) (eval expr ctx (- fuel 1)))) expr ctx)))))
+
+(define ((eval-fuel-stmt evaltor fuel [default #f]) stmts ctx)
+  (let/ec k
+    (define (eval expr ctx fuel)
+      (if (<= fuel 0)
+          (k default)
+          ((eval-expr* evaltor (curryr eval (- fuel 1))) expr ctx)))
+    
+    (let loop ([stmts stmts] [ctx ctx] [fuel fuel])
+      ((eval-stmts* (curryr eval fuel) (curryr loop (- fuel 1))) stmts ctx))))
+
+(define (random-exp k)
+  "Like (random (expt 2 k)), but k is allowed to be arbitrarily large"
+  (if (< k 31) ; Racket generates random numbers in the range [0, 2^32-2]; I think it's a bug
+      (random (expt 2 k))
+      (let ([head (* (expt 2 31) (random-exp (- k 31)))])
+        (+ head (random (expt 2 31))))))
+
+(define (sample-double)
+  (floating-point-bytes->real (integer->integer-bytes (random-exp 64) 8 #f)))
+
+(define (sample-single)
+  (real->single-flonum (floating-point-bytes->real (integer->integer-bytes (random-exp 32) 4 #f))))

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -1,30 +1,10 @@
 #lang racket
 
-(require "../tools/common.rkt" "../tools/core2c.rkt" "../tools/fpcore.rkt")
+(require "test-common.rkt" "../tools/common.rkt" "../tools/core2c.rkt" "../tools/fpcore.rkt")
 
 (define tests-to-run (make-parameter 10))
 (define test-file (make-parameter "/tmp/test.c"))
 (define fuel (make-parameter 1000))
-
-(define ((eval-fuel evaltor fuel [default #f]) expr ctx)
-  (let/ec k
-    (let eval ([expr expr] [ctx ctx] [fuel fuel])
-      (if (<= fuel 0)
-          (k default)
-          ((eval-expr* evaltor (λ (expr ctx) (eval expr ctx (- fuel 1)))) expr ctx)))))
-
-(define (random-exp k)
-  "Like (random (expt 2 k)), but k is allowed to be arbitrarily large"
-  (if (< k 31) ; Racket generates random numbers in the range [0, 2^32-2]; I think it's a bug
-      (random (expt 2 k))
-      (let ([head (* (expt 2 31) (random-exp (- k 31)))])
-        (+ head (random (expt 2 31))))))
-
-(define (sample-double)
-  (floating-point-bytes->real (integer->integer-bytes (random-exp 64) 8 #f)))
-
-(define (sample-single)
-  (real->single-flonum (floating-point-bytes->real (integer->integer-bytes (random-exp 32) 4 #f))))
 
 (define (compile->c prog test-file #:type [type 'binary64])
   (call-with-output-file test-file #:exists 'replace
@@ -89,7 +69,7 @@
                                            ['binary32 (sample-single)]))))
                  (define evaltor (match type ['binary64 racket-double-evaluator] ['binary32 racket-single-evaluator]))
                  (define out
-                   (match ((eval-fuel evaltor (fuel) 'timeout) body ctx)
+                   (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
                      [(? real? result)
                       ((match type
                          ['binary64 real->double-flonum] ['binary32 real->single-flonum])

--- a/infra/test-core2js.rkt
+++ b/infra/test-core2js.rkt
@@ -1,29 +1,11 @@
 #lang racket
 
-(require "../tools/common.rkt" "../tools/core2js.rkt" "../tools/fpcore.rkt")
+(require "test-common.rkt" "../tools/common.rkt" "../tools/core2js.rkt" "../tools/fpcore.rkt")
 
 ;; The output file requires mathjs to be installed
 (define tests-to-run (make-parameter 10))
 (define test-file (make-parameter "/tmp/test.js"))
 (define fuel (make-parameter 1000))
-
-(define ((eval-fuel evaltor fuel [default #f]) expr ctx)
-  (let/ec k
-    (let eval ([expr expr] [ctx ctx] [fuel fuel])
-      (if (<= fuel 0)
-        (k default)
-        ((eval-expr* evaltor (λ (expr ctx) (eval expr ctx (- fuel 1)))) expr ctx)))))
-
-;; TODO: add support for multiple types
-(define (random-exp k)
-  "Like (random (expt 2 k)), but k is allowed to be arbitrarily large"
-  (if (< k 31) ; Racket generates random numbers in the range [0, 2^32-2]; I think it's a bug
-      (random (expt 2 k))
-      (let ([head (* (expt 2 31) (random-exp (- k 31)))])
-        (+ head (random (expt 2 31))))))
-
-(define (sample-double)
-  (floating-point-bytes->real (integer->integer-bytes (random-exp 64) 8 #f)))
 
 (define (compile->js prog test-file)
   (call-with-output-file test-file #:exists 'replace
@@ -50,6 +32,7 @@
       ["Infinity" "+inf.0"]
       ["-Infinity" "-inf.0"]
       [(? string->number x) x]
+      [(? (λ (x) (string-contains? x "im:"))) "+nan.0"] ;; other js complex format
       [(? (λ (x) (string-contains? x "{ [String:"))) "+nan.0"])) ;; js complex format
   ;; javascript can return complex numbers which the reference implementation
   ;; doesn't have (returns NaN). This is a consequence of the mathjs library
@@ -94,7 +77,7 @@
                                (cons var (sample-double))))
                  (define evaltor racket-double-evaluator)
                  (define out
-                   (match ((eval-fuel evaltor (fuel) 'timeout) body ctx)
+                   (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
                      [(? real? result)
                       (real->double-flonum result)]
                      [(? complex? result)

--- a/infra/test-core2smtlib2.rkt
+++ b/infra/test-core2smtlib2.rkt
@@ -73,6 +73,10 @@
     (match-define (list 'FPCore (list vars ...) props* ... body) prog)
     (define-values (_ props) (parse-properties props*))
     (define type (dict-ref props ':precision 'binary64))
+    (define-values (w p)
+        (match type
+          ['binary32 (values 8 24)]
+          ['binary64 (values 11 53)]))
     (define timeout 0)
     (define results
       (for/list ([i (in-range (tests-to-run))])
@@ -105,8 +109,9 @@
                                              [_ (format " (~a timeouts)" timeout)]))
       (set! err (+ err (count (λ (x) (not (=* (second x) (third x)))) results)))
       (for ([x (in-list results)] #:unless (=* (second x) (third x)))
-        (printf "\t~a ≠ ~a @ ~a\n" (second x) (third x)
-                (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
+        (printf "\t~a ≠ ~a @ ~a\n\t~a\n" (second x) (third x)
+                (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")
+                (string-join (map (λ (x) (format "~a = ~a" (car x) (number->smt (cdr x) w p 'nearestEven))) (first x)) ", ")))))
   err)
 
 (module+ main

--- a/infra/test-core2smtlib2.rkt
+++ b/infra/test-core2smtlib2.rkt
@@ -127,4 +127,4 @@
    #:args ()
 
    (let ([error (run-tests (current-input-port) "stdin")])
-     exit error)))
+     (exit error))))

--- a/infra/test-core2smtlib2.rkt
+++ b/infra/test-core2smtlib2.rkt
@@ -4,7 +4,7 @@
 
 (define tests-to-run (make-parameter 10))
 (define test-file (make-parameter "/tmp/test.smtlib2"))
-(define fuel (make-parameter 1000))
+(define fuel (make-parameter 100))
 
 (define (translate->smt prog ctx test-file #:type type)
   (call-with-output-file test-file #:exists 'replace

--- a/infra/test-core2smtlib2.rkt
+++ b/infra/test-core2smtlib2.rkt
@@ -1,0 +1,125 @@
+#lang racket
+
+(require "test-common.rkt" "../tools/common.rkt" "../tools/core2smtlib2.rkt" "../tools/fpcore.rkt")
+
+(define tests-to-run (make-parameter 10))
+(define test-file (make-parameter "/tmp/test.smtlib2"))
+(define fuel (make-parameter 1000))
+
+(define (translate->smt prog ctx test-file #:type type)
+  (call-with-output-file test-file #:exists 'replace
+    (lambda (port)
+      (define-values (w p)
+        (match type
+          ['binary32 (values 8 24)]
+          ['binary64 (values 11 53)]))
+      (fprintf port "~a\n\n" (compile-program prog #:name "f"))
+      (for ([arg ctx] [i (in-naturals)])
+        (match-define (cons var value) arg)
+        (fprintf port "(define-const arg~a (_ FloatingPoint ~a ~a) ~a)\n"
+                 i w p (number->smt value w p 'nearestEven)))
+      (fprintf port "(check-sat)\n")
+      (fprintf port "(eval (f ~a))\n"
+               (string-join
+                (for/list ([i (in-range (length ctx))])
+                  (format "arg~a" i))
+                " "))))
+  test-file)
+
+(define (run<-smt exec-name #:type type)
+  (let*
+      ([out (with-output-to-string
+              (lambda ()
+                (system (format "z3 ~a" exec-name))))]
+       [fp (last (string-split out "\n"))]
+       [stx (read-syntax exec-name (open-input-string fp))])
+    (match (syntax-e stx)
+      [(list (app syntax-e '_) (app syntax-e 'NaN) stxw stxp)
+       (match type
+         ['binary32 +nan.f]
+         ['binary64 +nan.0])]
+      [(list (app syntax-e '_) (app syntax-e '+oo) stxw stxp)
+       (match type
+         ['binary32 +inf.f]
+         ['binary64 +inf.0])]
+      [(list (app syntax-e '_) (app syntax-e '-oo) stxw stxp)
+       (match type
+         ['binary32 -inf.f]
+         ['binary64 -inf.0])]
+      [(list (app syntax-e '_) (app syntax-e '+zero) stxw stxp) 0.0]
+      [(list (app syntax-e '_) (app syntax-e '-zero) stxw stxp) -0.0]
+      [(list (app syntax-e 'fp) stxS stxE stxC)
+       (let
+           ([S (syntax->datum stxS)]
+            [E (syntax->datum stxE)]
+            [C (syntax->datum stxC)])
+         (match type
+           ['binary32
+            (floating-point-bytes->real (integer->integer-bytes
+                                         (bitwise-ior (arithmetic-shift S 31) (arithmetic-shift E 23) C)
+                                         4 #f))]
+           ['binary64
+            (floating-point-bytes->real (integer->integer-bytes
+                                         (bitwise-ior (arithmetic-shift S 63) (arithmetic-shift E 52) C)
+                                         8 #f))]))])))
+
+(define (=* a b)
+  (or (equal? a b) (= a b) (and (nan? a) (nan? b))))
+
+(define (run-tests p file)
+  (define err 0)
+  (port-count-lines! p)
+  (for ([prog (in-port (curry read-fpcore file) p)])
+    (match-define (list 'FPCore (list vars ...) props* ... body) prog)
+    (define-values (_ props) (parse-properties props*))
+    (define type (dict-ref props ':precision 'binary64))
+    (define timeout 0)
+    (define results
+      (for/list ([i (in-range (tests-to-run))])
+        (define ctx (for/list ([var vars])
+                      (cons var (match type
+                                  ['binary64 (sample-double)]
+                                  ['binary32 (sample-single)]))))
+        (define exec-file (translate->smt prog ctx (test-file) #:type type))
+        (define evaltor (match type ['binary64 racket-double-evaluator] ['binary32 racket-single-evaluator]))
+        (define out
+          (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
+            [(? real? result)
+             ((match type
+                ['binary64 real->double-flonum] ['binary32 real->single-flonum])
+              result)]
+            [(? complex? result)
+             (match type
+               ['binary64 +nan.0] ['binary32 +nan.f])]
+            ['timeout 'timeout]
+            [(? boolean? result) result]))
+        (when (equal? out 'timeout)
+          (set! timeout (+ timeout 1)))
+        (define out* (if (equal? out 'timeout) 'timeout (run<-smt exec-file #:type type)))
+        (list ctx out out*)))
+    (unless (null? results)
+      (printf "~a/~a: ~a~a\n" (count (λ (x) (=* (second x) (third x))) results) (length results)
+              (dict-ref props ':name body) (match timeout
+                                             [0 ""]
+                                             [1 " (1 timeout)"]
+                                             [_ (format " (~a timeouts)" timeout)]))
+      (set! err (+ err (count (λ (x) (not (=* (second x) (third x)))) results)))
+      (for ([x (in-list results)] #:unless (=* (second x) (third x)))
+        (printf "\t~a ≠ ~a @ ~a\n" (second x) (third x)
+                (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
+  err)
+
+(module+ main
+  (command-line
+   #:program "test/compiler.rkt"
+   #:once-each
+   ["--fuel" fuel_ "Number of computation steps to allow"
+    (fuel (string->number fuel_))]
+   ["--repeat" repeat_ "Number of times to test each program"
+    (tests-to-run (string->number repeat_))]
+   ["-o" name_ "Name for generated C file"
+    (test-file name_)]
+   #:args ()
+
+   (let ([error (run-tests (current-input-port) "stdin")])
+     exit error)))

--- a/infra/test-imp2core.rkt
+++ b/infra/test-imp2core.rkt
@@ -1,39 +1,9 @@
 #lang racket
 
-(require "../tools/common.rkt" "../tools/imp2core.rkt" "../tools/fpcore.rkt" "../tools/fpimp.rkt")
+(require "test-common.rkt" "../tools/common.rkt" "../tools/imp2core.rkt" "../tools/fpcore.rkt" "../tools/fpimp.rkt")
 
 (define tests-to-run (make-parameter 10))
 (define fuel (make-parameter 1000))
-
-(define ((eval-fuel-expr evaltor fuel [default #f]) expr ctx)
-  (let/ec k
-    (let eval ([expr expr] [ctx ctx] [fuel fuel])
-      (if (<= fuel 0)
-          (k default)
-          ((eval-expr* evaltor (λ (expr ctx) (eval expr ctx (- fuel 1)))) expr ctx)))))
-
-(define ((eval-fuel-stmt evaltor fuel [default #f]) stmts ctx)
-  (let/ec k
-    (define (eval expr ctx fuel)
-      (if (<= fuel 0)
-          (k default)
-          ((eval-expr* evaltor (curryr eval (- fuel 1))) expr ctx)))
-    
-    (let loop ([stmts stmts] [ctx ctx] [fuel fuel])
-      ((eval-stmts* (curryr eval fuel) (curryr loop (- fuel 1))) stmts ctx))))
-
-(define (random-exp k)
-  "Like (random (expt 2 k)), but k is allowed to be arbitrarily large"
-  (if (< k 31) ; Racket generates random numbers in the range [0, 2^32-2]; I think it's a bug
-      (random (expt 2 k))
-      (let ([head (* (expt 2 31) (random-exp (- k 31)))])
-        (+ head (random (expt 2 31))))))
-
-(define (sample-double)
-  (floating-point-bytes->real (integer->integer-bytes (random-exp 64) 8 #f)))
-
-(define (sample-single)
-  (real->single-flonum (floating-point-bytes->real (integer->integer-bytes (random-exp 32) 4 #f))))
 
 (define (=* a b)
   (or (equal? a 'timeout) (ormap (curryr equal? 'timeout) b)

--- a/tools/core2smtlib2.rkt
+++ b/tools/core2smtlib2.rkt
@@ -44,7 +44,10 @@
     [(or +inf.0 +inf.f) (format "(_ +oo ~a ~a)" w p)]
     [(or -inf.0 -inf.f) (format "(_ -oo ~a ~a)" w p)]
     [(or +nan.0 +nan.f) (format "(_ NaN ~a ~a)" w p)]
-    [_ (let* ([q (inexact->exact x)]
+    [_ (let* ([q (if (single-flonum? x)
+                     ;; Workaround for misbehavior of inexact->exact with single-flonum inputs
+                     (inexact->exact (real->double-flonum x))
+                     (inexact->exact x))]
               [n (numerator q)]
               [d (denominator q)])
          (if (= d 1)

--- a/tools/core2smtlib2.rkt
+++ b/tools/core2smtlib2.rkt
@@ -1,0 +1,237 @@
+#lang racket
+
+(require math/bigfloat)
+(require "common.rkt" "fpcore.rkt")
+(provide compile-program)
+
+;; Extremely simple html-inspired escapes. The understanding is that the
+;; only difference between symbols is that FPCore allows : in names,
+;; while SML-LIB does not.
+(define (fix-name name)
+  (string-join
+   (for/list ([char (~a name)])
+     (match char
+       [#\& "&amp"]
+       [#\: "&col"]
+       [_ (string char)]))
+   ""))
+
+(define (fptype w p)
+  (format "(_ FloatingPoint ~a ~a)" w p))
+
+(define/match (rm->bf rm)
+  [('nearestEven) 'nearest]
+  ;[('nearestAway) ] ;; math/bigfloat does not support this mode
+  [('toPositive) 'up]
+  [('toNegative) 'down]
+  [('toZero) 'zero]
+  [(_) (error 'rm->bf "Unsupported rounding mode ~a" rm)])
+
+(define/match (rm->smt rm)
+  [('nearestEven) "roundNearestTiesToEven"]
+  [('nearestAway) "roundNearestTiesToAway"]
+  [('toPositive) "roundTowardPositive"]
+  [('toNegative) "roundTowardNegative"]
+  [('toZero) "roundTowardZero"]
+  [(_) (error 'rm->smt "Unsupported rounding mode ~a" rm)])
+
+;; Any exact number can be written out (exactly) as a division. In general, adding
+;; lots of real divisions to a formula is probably not wise.
+;; However, at least with z3, defining constants in this way does not seem to cause
+;; any significant issues.
+(define (rational->smt q w p rm)
+  (let ([n (numerator q)]
+        [d (denominator q)])
+    (if (= d 1)
+        (format "((_ to_fp ~a ~a) ~a ~a)" w p (rm->smt rm) n)
+        (format "((_ to_fp ~a ~a) ~a (/ ~a ~a))" w p (rm->smt rm) n d))))
+
+;; Macro should grab the computation specified in the constants table
+;; and wrap it with the right precision context.
+(define-syntax-rule (bf-constant expr w p rm)
+  (begin
+   (bf-precision p)
+   ;; It is critical that we use the correct rounding mode, and the correct number of bits,
+   ;; here where we are generating the exact (but rounded) value of the constant.
+   (bf-rounding-mode (rm->bf rm))
+   (let ([qbf expr])
+     ;; In theory the rounding mode used here doesn't matter.
+     (rational->smt (bigfloat->rational qbf) w p rm)))
+  )
+
+(define (constant->smt c w p rm)
+  (match c
+    ['E (bf-constant (bfexp 1.bf) w p rm)]
+    ;['LOG2E ""]
+    ;['LOG10E ""]
+    ['LN2 (bf-constant (bflog 2.bf) w p rm)]
+    ['LN10 (bf-constant (bflog 10.bf) w p rm)]
+    ['PI (bf-constant pi.bf w p rm)]
+    ['PI_2 (bf-constant (bf/ pi.bf 2.bf) w p rm)] ; ok since division by 2 is exact
+    ['PI_4 (bf-constant (bf/ pi.bf 4.bf) w p rm)] ; ok since division by 4 is exact
+    ;['1_PI ""]
+    ;['2_PI ""]
+    ;['2_SQRTPI ""]
+    ['SQRT2 (bf-constant (bfsqrt 2.bf) w p rm)]
+    ['SQRT1_2 (bf-constant (bfsqrt (bf/ 1.bf 2.bf)) w p rm)]
+    ['TRUE "true"]
+    ['FALSE "false"]
+    ['INFINITY "(_ +oo 11 53)"]
+    ['NAN "(_ NaN 11 53)"]
+    [_ (error 'constant->smt "Unsupported constant ~a" c)]))
+
+(define (operator->smt op rm)
+  (match op
+    ['+ (format "(fp.add ~a ~~a ~~a)" (rm->smt rm))]
+    ['- (format "(fp.sub ~a ~~a ~~a)" (rm->smt rm))]
+    ['* (format "(fp.mul ~a ~~a ~~a)" (rm->smt rm))]
+    ['/ (format "(fp.div ~a ~~a ~~a)" (rm->smt rm))]
+    ['fabs "(fp.abs ~a)"]
+    ['fma (format "(fp.fma ~a ~~a ~~a ~~a)" (rm->smt rm))]
+    ;['exp ""]
+    ;['exp2 ""]
+    ;['expm1 ""]
+    ;['log ""]
+    ;['log10 ""]
+    ;['log2 ""]
+    ;['log1p ""]
+    ;['pow ""]
+    ['sqrt (format "(fp.sqrt ~a ~~a)" (rm->smt rm))]
+    ;['cbrt ""]
+    ;['hypot ""]
+    ;['sin ""]
+    ;['cos ""]
+    ;['tan ""]
+    ;['asin ""]
+    ;['acos ""]
+    ;['atan ""]
+    ;['atan2 ""]
+    ;['sinh ""]
+    ;['cosh ""]
+    ;['tanh ""]
+    ;['asinh ""]
+    ;['acosh ""]
+    ;['atanh ""]
+    ;['erf ""]
+    ;['erfc ""]
+    ;['tgamma ""]
+    ;['lgamma ""]
+    ;['ceil ""]
+    ;['floor ""]
+    ;['fmod ""]
+    ;; The behavior of fp.rem may not be fully compliant with C11
+    ;; remainder function, however based on the documentation things
+    ;; seem promising.
+    ['remainder "(fp.rem ~a ~a)"]
+    ['fmax "(fp.max ~a ~a)"]
+    ['fmin "(fp.min ~a ~a)"]
+    ;['fdim ""]
+    ;['copysign ""]
+    ['trunc (format "(fp.roundToIntegral ~a ~~a)" (rm->smt 'toZero))]
+    ['round (format "(fp.roundToIntegral ~a ~~a)" (rm->smt 'nearestAway))]
+    ['nearbyint (format "(fp.roundToIntegral ~a ~~a)" (rm->smt rm))]
+    ;; Comparisons and logical ops take one format argument,
+    ;; which is a pre-concatenated string of inputs.
+    ['< "(fp.lt ~a)"]
+    ['> "(fp.gt ~a)"]
+    ['<= "(fp.leq ~a)"]
+    ['>= "(fp.geq ~a)"]
+    ['== "(fp.eq ~a)"]
+    ;['!= ""] ;; needs special logic
+    ['and "(and ~a)"]
+    ['or "(or ~a)"]
+    ['not "(not ~a)"]
+    ['isfinite "(not (fp.isInfinite ~a))"]
+    ['isinf "(fp.isInfinite ~a)"]
+    ['isnan "(fp.isNaN ~a)"]
+    ['isnormal "(fp.isNormal ~a)"]
+    ['signbit "(fp.isNegative ~a)"]
+    [_ (error 'operator->smt "Unsupported operator ~a" op)]))
+
+(define (application->smt operator args rm)
+  (match (cons operator args)
+    [(list (or '< '> '<= '>= '== 'and 'or) args ...)
+     (format (operator->smt operator rm)
+             (string-join
+              (for/list ([a args]) (format "~a" a))
+              " "))]
+    [(list '!= args ...)
+     (format "(and ~a)"
+             (string-join
+              (let loop ([args args])
+                (if (null? args)
+                    '()
+                    (append
+                     (for/list ([b (cdr args)])
+                       (format "(not (fp.eq ~a ~a))" (car args) b))
+                     (loop (cdr args)))))
+              " "))]
+    [(list '- a)
+     (format "(fp.neg ~a)" a)]
+    [(list (? operator? op) args ...)
+     (apply format (operator->smt op rm) args)]
+    [_ (error 'application->smt "Unsupported application ~a ~a" operator args)]))
+
+(define (expr->smt expr w p rm)
+  (match expr
+    [`(let ([,vars ,vals] ...) ,body)
+     (format "(let (~a) ~a)"
+             (string-join
+              (for/list ([var vars] [val vals])
+                (format "(~a ~a)"
+                        (fix-name var) (expr->smt val w p rm)))
+              " ")
+             (expr->smt body w p rm))]
+    [`(if ,condition ,true-branch ,false-branch)
+     (format "(ite ~a ~a ~a)"
+             (expr->smt condition w p rm)
+             (expr->smt true-branch w p rm)
+             (expr->smt false-branch w p rm))]
+    [`(while ,condition ([,vars ,inits ,updates] ...) ,body)
+     (error 'expr->smt "Loop unrolling not supported: ~a" expr)]
+    [(list (? operator? operator) args ...)
+     (application->smt operator
+                       (for/list ([arg args])
+                         (expr->smt arg w p rm))
+                       rm)]
+    [(? constant?)
+     (constant->smt expr w p rm)]
+    [(? symbol?)
+     (fix-name expr)]
+    [(? number?)
+     (rational->smt expr w p rm)]
+    [_ (error 'expr->smt "Unsupported expr ~a" expr)]))
+
+(define (compile-program prog #:name name)
+  (match-define (list 'FPCore (list args ...) props ... body) prog)
+  (define-values (_ properties) (parse-properties props))
+  (define type (dict-ref properties ':precision 'binary64))
+  (define rm (dict-ref properties ':round 'nearestEven))
+
+  (define-values (w p)
+    (match type
+      ['binary16 (values 5 11)]
+      ['binary32 (values 8 24)]
+      ['binary64 (values 11 53)]
+      ['binary128 (values 15 113)]
+      [_ (error 'compile-program "Unsupported precision type ~a" type)]))
+
+  (define arg-strings
+    (for/list ([var args])
+      (format "(~a ~a)" (fix-name (if (list? var) (car var) var)) (fptype w p))))
+
+  (format "(define-fun ~a (~a) ~a\n ~a)"
+          (fix-name name)
+          (string-join arg-strings " ")
+          (fptype w p)
+          (expr->smt body w p rm)))
+
+(module+ main
+  (require racket/cmdline)
+
+  (command-line
+   #:program "compile.rkt"
+   #:args ()
+   (port-count-lines! (current-input-port))
+   (for ([expr (in-port (curry read-fpcore "stdin"))] [n (in-naturals)])
+     (printf "~a\n" (compile-program expr #:name (format "ex~a" n))))))


### PR DESCRIPTION
Somewhat tested with Z3. Known caveats:
  * Not all functions (sin, log, floor, etc.) are supported. This compiler
    will thrown an error.
  * Some mathematical constants are harder to compute exactly than others using
    math/bigfloat, and thus are not supported. This compiler will throw an error.
  * Four precisions are supported: binary16, binary32, binary64, and binary128.
  * The five IEEE rounding modes are supported: nearestEven, nearestAway, toZero,
    toPositive, and toNegative. Due to limitations of math/bigfloat, nearestAway
    is not supported for mathematical constants.