### PR TITLE
add arclength benchmark

### DIFF
--- a/benchmarks.bib
+++ b/benchmarks.bib
@@ -149,3 +149,12 @@
   publisher = {{ACM}},
   year      = {2015},
 }
+
+@inproceedings{precimonious-2013,
+  title = {Precimonious: Tuning assistant for floating-point precision},
+  author = {Rubio-Gonz{\'a}lez, Cindy and Nguyen, Cuong and Nguyen, Hong Diep and Demmel, James and Kahan, William and Sen, Koushik and Bailey, David H and Iancu, Costin and Hough, David},
+  booktitle = {High Performance Computing, Networking, Storage and Analysis (SC), 2013 International Conference for},
+  pages = {1--12},
+  year = {2013},
+  organization = {IEEE}
+}

--- a/benchmarks/precimonious.fpcore
+++ b/benchmarks/precimonious.fpcore
@@ -1,0 +1,43 @@
+;; -*- mode: scheme -*-
+
+(FPCore (n)
+ :name "arclength"
+ :cite (precimonious-2013)
+ :precision binary64
+ :pre (>= n 0)
+ (let ([dppi (acos -1.0)])
+   (let ([h (/ dppi n)])
+     (while (<= i n)
+      ([s1
+        0.0
+        (let ([t2 (let ([x (* i h)])
+                    ;; inlined body of fun
+                    (while (<= k 5)
+                     ([d0
+                       (! :precision binary32 2.0)
+                       (! :precision binary32 (* 2.0 d0))]
+                      [t0
+                       x
+                       (+ t0 (/ (sin (* d0 x)) d0))]
+                      [k 1 (+ k 1)])
+                     t0))])
+          (let ([s0 (sqrt (+ (* h h) (* (- t2 t1) (- t2 t1))))])
+            (! :precision binary128 (+ s1 s0))))]
+       [t1
+        0.0
+        (let ([t2 (let ([x (* i h)])
+                    ;; inlined body of fun
+                    (while (<= k 5)
+                     ([d0
+                       (! :precision binary32 2.0)
+                       (! :precision binary32 (* 2.0 d0))]
+                      [t0
+                       x
+                       (+ t0 (/ (sin (* d0 x)) d0))]
+                      [k 1 (+ k 1)])
+                     t0))])
+          t2)]
+       [i
+        1
+        (+ i 1)])
+      s1))))


### PR DESCRIPTION
This is the arclength benchmark used as an example in the FPBench 1.1 standard update proposal.

The precimonious paper examines 12 programs, including arclength - this is the only one with source readily available in the paper. It might be a good idea to port the other benchmarks as well.