### PR TITLE
FPCore to Mathematica (Wolfram Language) compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ test:
 	cat benchmarks/*.fpcore | racket tools/filter.rkt precision binary32 binary64 \
 	| racket tools/filter.rkt operators "+" "-" "*" "/" fabs fma sqrt remainder fmax fmin trunc round nearbyint "<" ">" "<=" ">=" "==" "!=" and or not isfinite isinf isnan isnormal signbit \
 	| racket infra/test-core2smtlib2.rkt
+ifneq (, $(shell which wolframscript))
+	cat benchmarks/*.fpcore | racket tools/filter.rkt precision binary32 binary64 \
+	| racket tools/filter.rkt --invert operators fmod remainder trunc round isfinite isinf isnan isnormal signbit \
+	| racket infra/test-core2wls.rkt
+endif
 
 %.fpcore: %.fpimp
 	printf ";; -*- mode: scheme -*-\n\n" > $@

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ test:
 	| racket infra/test-core2smtlib2.rkt
 ifneq (, $(shell which wolframscript))
 	cat benchmarks/*.fpcore | racket tools/filter.rkt precision binary32 binary64 \
-	| racket tools/filter.rkt --invert operators fmod remainder trunc round isfinite isinf isnan isnormal signbit \
 	| racket infra/test-core2wls.rkt
 endif
 

--- a/infra/test-core2wls.rkt
+++ b/infra/test-core2wls.rkt
@@ -1,0 +1,112 @@
+#lang racket
+
+(require math/flonum)
+(require "test-common.rkt" "../tools/common.rkt" "../tools/core2wls.rkt" "../tools/fpcore.rkt")
+
+(define tests-to-run (make-parameter 10))
+(define test-file (make-parameter "/tmp/test.wls"))
+(define fuel (make-parameter 1000))
+;(define ulps (make-parameter 0))
+
+(define (translate->wls prog ctx test-file)
+  (call-with-output-file test-file #:exists 'replace
+    (lambda (port)
+      (fprintf port "~a\n" (compile-program prog #:name "f"))
+      (fprintf port
+               (format "TimeConstrained[MemoryConstrained[Print[f[~a] // N], 2^32], 5]\n"
+                       (string-join (map number->wls (map cdr ctx)) ", ")))))
+  test-file)
+
+(define (run<-wls exec-name)
+  (let*
+      ([out (with-output-to-string
+              (lambda ()
+                (system (format "wolframscript -script ~a" exec-name))))]
+       [fp (match (string-split (string-trim out) "\n")
+             ['() ""]
+             [s (last s)])]
+       [out* (match fp
+               ["Infinity" "+inf.0"]
+               ["-Infinity" "-inf.0"]
+               ["ComplexInfinity" "+nan.0"]
+               ["Indeterminate" "+nan.0"]
+               [(? string->number x) x]
+               [else "+nan.0"])])
+    (string->number out*)))
+
+(define (=* a b)
+  (match (list a b)
+    ['(timeout timeout) true]
+    [else
+     (or (= a b)
+         ;(<= (abs (flonums-between a b)) (ulps))
+         (nan? a)
+         (nan? b))]))
+
+(define (run-tests p file)
+  (define err 0)
+  (port-count-lines! p)
+  (for ([prog (in-port (curry read-fpcore file) p)])
+    (match-define (list 'FPCore (list vars ...) props* ... body) prog)
+    (define-values (_ props) (parse-properties props*))
+    (define type (dict-ref props ':precision 'binary64))
+    (define timeout 0)
+    (define nans 0)
+    (define results
+      (for/list ([i (in-range (tests-to-run))])
+        (define ctx (for/list ([var vars])
+                      (cons var (match type
+                                  ['binary64 (sample-double)]
+                                  ['binary32 (sample-single)]))))
+        (define exec-file (translate->wls prog ctx (test-file)))
+        (define evaltor (match type ['binary64 racket-double-evaluator] ['binary32 racket-single-evaluator]))
+        (define out
+          (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
+            [(? real? result)
+             ((match type
+                ['binary64 real->double-flonum] ['binary32 real->single-flonum])
+              result)]
+            [(? complex? result)
+             (match type
+               ['binary64 +nan.0] ['binary32 +nan.f])]
+            ['timeout 'timeout]
+            [(? boolean? result) result]))
+        (when (equal? out 'timeout)
+          (set! timeout (+ timeout 1)))
+        (define out* (if (equal? out 'timeout) 'timeout (run<-wls exec-file)))
+        (when (and (not (equal? out 'timeout)) (or (nan? out) (nan? out*)))
+          (set! nans (+ nans 1)))
+        (list ctx out out*)))
+    (unless (null? results)
+      (printf "~a/~a: ~a~a~a\n" (count (λ (x) (=* (second x) (third x))) results) (length results)
+              (dict-ref props ':name body)
+              (match timeout
+                [0 ""]
+                [1 " (1 timeout)"]
+                [_ (format " (~a timeouts)" timeout)])
+              (match nans
+                [0 ""]
+                [1 " (1 nan)"]
+                [_ (format " (~a nans)" nans)]))
+      (set! err (+ err (count (λ (x) (not (=* (second x) (third x)))) results)))
+      (for ([x (in-list results)] #:unless (=* (second x) (third x)))
+        (printf "\t~a ≠ ~a @ ~a\n" (second x) (third x)
+                (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
+  err)
+
+(module+ main
+  (command-line
+   #:program "test/compiler.rkt"
+   #:once-each
+   ["--fuel" fuel_ "Number of computation steps to allow"
+    (fuel (string->number fuel_))]
+   ["--repeat" repeat_ "Number of times to test each program"
+    (tests-to-run (string->number repeat_))]
+   ["-o" name_ "Name for generated C file"
+    (test-file name_)]
+   #:args ()
+
+   (let ([error (run-tests (current-input-port) "stdin")])
+     (printf "found ~a discrepancies\n" error)
+     ;; Warn, but don't actually fail and hold up the build
+     (exit 0))))

--- a/tools/core2math.rkt
+++ b/tools/core2math.rkt
@@ -1,0 +1,198 @@
+#lang racket
+
+(require "common.rkt" "fpcore.rkt")
+(provide compile-program)
+
+(define bad-chars (regexp "^[0-9]+|[^a-z0-9]+"))
+
+(define var-counter (box 1))
+(define (fix-name name names)
+  (if (hash-has-key? names name)
+      (hash-ref names name)
+      (let ([shortened (regexp-replace bad-chars name "")])
+        (if (string=? name shortened)
+            (begin
+              (hash-set! names name name)
+              name)
+            (let* ([counter (unbox var-counter)]
+                   [uniquified (string-append shortened "VAR" (number->string counter))])
+              (set-box! var-counter (+ counter 1))
+              (hash-set! names name uniquified)
+              uniquified)))))
+
+(define (number->math x)
+  (match x
+    [(or +inf.0 +inf.f) "Infinity"]
+    [(or -inf.0 -inf.f) "(-Infinity)"]
+    [(or +nan.0 +nan.f) "Indeterminate"]
+    [_ (let* ([q (if (single-flonum? x)
+                     ;; Workaround for misbehavior of inexact->exact with single-flonum inputs
+                     (inexact->exact (real->double-flonum x))
+                     (inexact->exact x))]
+              [n (numerator q)]
+              [d (denominator q)])
+         (if (= d 1)
+             (format "~a" n)
+             (format "(~a/~a)" n d)))]))
+
+(define (constant->math c)
+  (match c
+    ['E "E"]
+    ['LOG2E "Log[2, E]"]
+    ['LOG10E "Log[10, E]"]
+    ['LN2 "Log[2]"]
+    ['LN10 "Log[10]"]
+    ['PI "Pi"]
+    ['PI_2 "(Pi / 2)"]
+    ['PI_4 "(Pi / 4)"]
+    ['1_PI "(1 / Pi)"]
+    ['2_PI "(2 / Pi)"]
+    ['2_SQRTPI "(2 / Sqrt[Pi])"]
+    ['SQRT2 "Sqrt[2]"]
+    ['SQRT1_2 "Sqrt[1 / 2]"]
+    ['TRUE "True"]
+    ['FALSE "False"]
+    ['INFINITY "Infinity"]
+    ['NAN "Indeterminate"]
+    [_ (error 'constant->math "Unsupported constant ~a" c)]))
+
+(define (operator->math op)
+  (match op
+    ['+ "(~a + ~a)"]
+    ['- "(~a - ~a)"]
+    ['* "(~a * ~a)"]
+    ['/ "(~a / ~a)"]
+    ['fabs "Abs[~a]"]
+    ['fma "(~a * ~a + ~a)"]
+    ['exp "Exp[~a]"]
+    ['exp2 "Power[2, ~a]"]
+    ['expm1 "(Exp[~a] - 1)"]
+    ['log "Log[~a]"]
+    ['log10 "Log[10, ~a]"]
+    ['log2 "Log[2, ~a]"]
+    ['log1p "Log[1 + ~a]"]
+    ['pow "Power[~a, ~a]"]
+    ['sqrt "Sqrt[~a]"]
+    ['cbrt "Power[~a, 1/3]"]
+    ['hypot "Sqrt[~a^2 + ~a^2]"]
+    ['sin "Sin[~a]"]
+    ['cos "Cos[~a]"]
+    ['tan "Tan[~a]"]
+    ['asin "ArcSin[~a]"]
+    ['acos "ArcCos[~a]"]
+    ['atan "ArcTan[~a]"]
+    ['atan2 "ArcTan[~a / ~a]"]
+    ['sinh "Sinh[~a]"]
+    ['cosh "Cosh[~a]"]
+    ['tanh "Tanh[~a]"]
+    ['asinh "ArcSinh[~a]"]
+    ['acosh "ArcCosh[~a]"]
+    ['atanh "ArcTanh[~a]"]
+    ['erf "Erf[~a]"]
+    ['erfc "Erfc[~a]"]
+    ['tgamma "Gamma[~a]"]
+    ['lgamma "LogGamma[~a]"]
+    ['ceil "Ceiling[~a]"]
+    ['floor "Floor[~a]"]
+    ;; Mathematica's Mod[] function does not have the same
+    ;; behavior of either of these operations (as far as I
+    ;; can tell).
+    ;['fmod ""]
+    ;['remainder "(fp.rem ~a ~a)"]
+    ['fmax "Max[~a, ~a]"]
+    ['fmin "Min[~a, ~a]"]
+    ['fdim "Max[0, ~a - ~a]"]
+    ['copysign "(~a * Sign[~a])"]
+    ;; Mathematica's Round[] rounds to even integers, like
+    ;; nearbyint with the rounding mode set to RNE.
+    ;['trunc ""]
+    ;['round ""]
+    ['nearbyint "Round[~a]"]
+    ;; Comparisons and logical ops take one format argument,
+    ;; which is a pre-concatenated string of inputs
+    ;; (with commas separating them!)
+    ['< "Less[~a]"]
+    ['> "Greater[~a]"]
+    ['<= "LessEqual[~a]"]
+    ['>= "GreaterEqual[~a]"]
+    ['== "Equal[~a]"]
+    ['!= "Unequal[~a]"]
+    ['and "And[~a]"]
+    ['or "Or[~a]"]
+    ['not "Not[~a]"]
+    ;; These are a little complicated...
+    ;['isfinite ""]
+    ;['isinf ""]
+    ;['isnan "(~a === Indeterminate)"]
+    ;['isnormal ""]
+    ;['signbit "(Sign[~a] == -1)"]
+    [_ (error 'operator->math "Unsupported operator ~a" op)]))
+
+(define (application->math operator args)
+  (match (cons operator args)
+    [(list (or '< '> '<= '>= '== '!= 'and 'or) args ...)
+     (format (operator->math operator)
+             (string-join
+              (for/list ([a args]) (format "~a" a))
+              ", "))]
+    [(list '- a)
+     (format "(-~a)" a)]
+    [(list (? operator? op) args ...)
+     (apply format (operator->math op) args)]
+    [_ (error 'application->math "Unsupported application ~a ~a" operator args)]))
+
+(define (expr->math expr names)
+  (match expr
+    [`(if ,condition ,true-branch ,false-branch)
+     (format "If[~a, ~a, ~a]"
+             (expr->math condition names)
+             (expr->math true-branch names)
+             (expr->math false-branch names))]
+
+    [`(let ([,vars ,vals] ...) ,body)
+     (format "With[{~a}, ~a]"
+             (string-join
+              (for/list ([var vars] [val vals])
+                (format "~a = ~a"
+                        (fix-name (symbol->string var) names) (expr->math val names)))
+              ", ")
+             (expr->math body names))]
+    [`(while ,condition ([,vars ,inits ,updates] ...) ,body)
+     (error 'expr->math "Loops not supported: ~a" expr)]
+    [(list (? operator? operator) args ...)
+     (application->math operator
+                       (for/list ([arg args])
+                         (expr->math arg names)))]
+    [(? constant?)
+     (constant->math expr)]
+    [(? symbol?)
+     (fix-name (symbol->string expr) names)]
+    [(? number?)
+     (number->math expr)]
+    [_ (error 'expr->math "Unsupported expr ~a" expr)]))
+
+(define (compile-program prog #:name name)
+  (match-define (list 'FPCore (list args ...) props ... body) prog)
+
+  (define names (make-hash))
+
+  (define progname (fix-name name names))
+
+  (define argnames
+    (for/list ([var args])
+      (format "~a_" (fix-name (symbol->string (if (list? var) (car var) var)) names))))
+
+  (format "~a[~a] :=\n~a"
+          progname
+          (string-join argnames ", ")
+          (expr->math body names)))
+
+(module+ main
+  (require racket/cmdline)
+
+  (command-line
+   #:program "compile.rkt"
+   #:args ()
+   (port-count-lines! (current-input-port))
+   (for ([expr (in-port (curry read-fpcore "stdin"))] [n (in-naturals)])
+     (printf "~a\n" (compile-program expr #:name (format "ex~a" n))))))

--- a/tools/core2wls.rkt
+++ b/tools/core2wls.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "common.rkt" "fpcore.rkt")
-(provide compile-program)
+(provide compile-program number->wls)
 
 (define bad-chars (regexp "^[0-9]+|[^a-z0-9]+"))
 
@@ -9,7 +9,7 @@
 (define (fix-name name names)
   (if (hash-has-key? names name)
       (hash-ref names name)
-      (let ([shortened (regexp-replace bad-chars name "")])
+      (let ([shortened (regexp-replace* bad-chars name "")])
         (if (string=? name shortened)
             (begin
               (hash-set! names name name)

--- a/tools/core2wls.rkt
+++ b/tools/core2wls.rkt
@@ -170,7 +170,7 @@
                 ", ")
                (expr->wls condition names)
                (string-join
-                (for/list ([loopvar loopvarnames] [update-expr updates))
+                (for/list ([loopvar loopvarnames] [update-expr updates])
                   (format "~a = ~a" loopvar (expr->wls update-expr names)))
                 ", ")
                (string-join


### PR DESCRIPTION
This compiler ignores all precision annotations and converts FPCores into Wolfram Language as directly as possible. Infinity and NaN from floating-point land are translated into Infinity and Indeterminate, which don't necessarily have the same behavior. This is not meant to be a rigorous translation of the subtleties of floating-point edge cases and rounding behavior, but rather a low-overhead translation of simple mathematical expressions.

This inital version of the compiler is not complete or particularly well tested. Loops will be added soon.

It is not immediately obvious how to do automated testing, as proper tests require Mathematica to be installed (and thus a Mathematica license...). There are also some potentially tricky edge cases, for example with Mathematica continuing computations with imaginary numbers.