### PR TITLE
Common Subexpression Eliminator

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1,18 +1,42 @@
 #lang racket/base
 
-(require "tools/canonicalizer.rkt" "tools/common.rkt" "tools/core2c.rkt"
-  "tools/core2fptaylor.rkt" "tools/core2gappa.rkt" "tools/core2go.rkt"
-  "tools/core2js.rkt" "tools/core2json.rkt" "tools/core2scala.rkt"
-  "tools/core2smtlib2.rkt" "tools/core2wls.rkt" "tools/filter.rkt"
-  "tools/fpimp.rkt" "tools/imp2core.rkt" "tools/range-analysis.rkt"
-  "tools/sample-accuracy.rkt" "tools/common-subexpr-elim.rkt")
+(require
+ "src/canonicalizer.rkt"
+ "src/common.rkt"
+ "src/core2c.rkt"
+ "src/core2fptaylor.rkt"
+ "src/core2gappa.rkt"
+ "src/core2go.rkt"
+ "src/core2js.rkt"
+ "src/core2scala.rkt"
+ "src/core2smtlib2.rkt"
+ "src/core2wls.rkt"
+ "infra/core2json.rkt"
+ "infra/filter.rkt"
+ "tools/fpimp.rkt"
+ "tools/imp2core.rkt"
+ "src/range-analysis.rkt"
+ "src/sample-accuracy.rkt"
+ "src/common-subexr-elim.rkt")
 
-(provide (all-from-out "tools/canonicalizer.rkt" "tools/common.rkt"
-  "tools/core2c.rkt" "tools/core2fptaylor.rkt" "tools/core2gappa.rkt"
-  "tools/core2go.rkt" "tools/core2js.rkt" "tools/core2json.rkt"
-  "tools/core2scala.rkt" "tools/core2smtlib2.rkt" "tools/core2wls.rkt"
-  "tools/filter.rkt" "tools/fpimp.rkt" "tools/imp2core.rkt"
-  "tools/range-analysis.rkt" "tools/sample-accuracy.rkt"
-  "tools/common-subexpr-elim.rkt"))
+(provide
+ (all-from-out
+  "src/canonicalizer.rkt"
+  "src/common.rkt"
+  "src/core2c.rkt"
+  "src/core2fptaylor.rkt"
+  "src/core2gappa.rkt"
+  "src/core2go.rkt"
+  "src/core2js.rkt"
+  "src/core2scala.rkt"
+  "src/core2smtlib2.rkt"
+  "src/core2wls.rkt"
+  "infra/core2json.rkt"
+  "infra/filter.rkt"
+  "tools/fpimp.rkt"
+  "tools/imp2core.rkt"
+  "src/range-analysis.rkt"
+  "src/sample-accuracy.rkt"
+  "src/common-subexpr-elim.rkt"))
 
 (module+ main)

--- a/main.rkt
+++ b/main.rkt
@@ -1,40 +1,18 @@
 #lang racket/base
 
-(require
- "src/canonicalizer.rkt"
- "src/common.rkt"
- "src/core2c.rkt"
- "src/core2fptaylor.rkt"
- "src/core2gappa.rkt"
- "src/core2go.rkt"
- "src/core2js.rkt"
- "src/core2scala.rkt"
- "src/core2smtlib2.rkt"
- "src/core2wls.rkt"
- "infra/core2json.rkt"
- "infra/filter.rkt"
- "tools/fpimp.rkt"
- "tools/imp2core.rkt"
- "src/range-analysis.rkt"
- "src/sample-accuracy.rkt")
+(require "tools/canonicalizer.rkt" "tools/common.rkt" "tools/core2c.rkt"
+  "tools/core2fptaylor.rkt" "tools/core2gappa.rkt" "tools/core2go.rkt"
+  "tools/core2js.rkt" "tools/core2json.rkt" "tools/core2scala.rkt"
+  "tools/core2smtlib2.rkt" "tools/core2wls.rkt" "tools/filter.rkt"
+  "tools/fpimp.rkt" "tools/imp2core.rkt" "tools/range-analysis.rkt"
+  "tools/sample-accuracy.rkt" "tools/common-subexpr-elim.rkt")
 
-(provide
- (all-from-out
-  "src/canonicalizer.rkt"
-  "src/common.rkt"
-  "src/core2c.rkt"
-  "src/core2fptaylor.rkt"
-  "src/core2gappa.rkt"
-  "src/core2go.rkt"
-  "src/core2js.rkt"
-  "src/core2scala.rkt"
-  "src/core2smtlib2.rkt"
-  "src/core2wls.rkt"
-  "infra/core2json.rkt"
-  "infra/filter.rkt"
-  "tools/fpimp.rkt"
-  "tools/imp2core.rkt"
-  "src/range-analysis.rkt"
-  "src/sample-accuracy.rkt"))
+(provide (all-from-out "tools/canonicalizer.rkt" "tools/common.rkt"
+  "tools/core2c.rkt" "tools/core2fptaylor.rkt" "tools/core2gappa.rkt"
+  "tools/core2go.rkt" "tools/core2js.rkt" "tools/core2json.rkt"
+  "tools/core2scala.rkt" "tools/core2smtlib2.rkt" "tools/core2wls.rkt"
+  "tools/filter.rkt" "tools/fpimp.rkt" "tools/imp2core.rkt"
+  "tools/range-analysis.rkt" "tools/sample-accuracy.rkt"
+  "tools/common-subexpr-elim.rkt"))
 
 (module+ main)

--- a/main.rkt
+++ b/main.rkt
@@ -17,7 +17,7 @@
  "tools/imp2core.rkt"
  "src/range-analysis.rkt"
  "src/sample-accuracy.rkt"
- "src/common-subexr-elim.rkt")
+ "src/common-subexpr-elim.rkt")
 
 (provide
  (all-from-out

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -110,6 +110,10 @@
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((i0 (- a a))) (- (+ (+ a a) (+ a a)) i0))))
     '(FPCore (a) (let ((i0 (- a a))) (- (+ (+ a a) (+ a a)) i0))))
+
+  (check-equal?
+    (core-common-subexpr-elim '(FPCore (a) (let ((x (- a a))) (let ((x (+ a a))) x))))
+    '(FPCore (a) (let ((x (- a a))) (let ((x (+ a a))) x))))
   
   
 )

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -74,13 +74,13 @@
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (+ (+ a a) (+ a a))))
-    '(FPCore (a) (let* ((i0 (+ a a))) (+ i0 i0))))
+    '(FPCore (a) (let* ((i (+ a a))) (+ i i))))
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a x) (+
                                                (- (+ a x) a)
                                                (- (+ a x) a))))
-    '(FPCore (a x) (let* ((i0 (+ a x)) (i1 (- i0 a))) (+ i1 i1))))
+    '(FPCore (a x) (let* ((i (+ a x)) (i1 (- i a))) (+ i1 i1))))
   
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((j0 (+ a a))) j0)))
@@ -88,11 +88,11 @@
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((j0 (+ a a))) (+ (+ a a) j0))))
-    '(FPCore (a) (let* ((i0 (+ a a))) (+ i0 i0))))
+    '(FPCore (a) (let* ((i (+ a a))) (+ i i))))
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((i0) (- a a)) (- (+ (+ a a) (+ a a)) i0))))
-    '(FPCore (a) (let* ((i0 (- a a)) (i1 (+ a a))) (- (+ i1 i1) i0))))
+    '(FPCore (a) (let* ((i (- a a)) (i1 (+ a a))) (- (+ i1 i1) i))))
 
   
 )

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -28,11 +28,12 @@
        cs-hash)]
     [else (make-hash)]))
 
-(define (common-subexpr-elim cs-hash expr)
+(define (common-subexpr-elim cs-hash start-expr)
   (define intermediates '())
   (define name-hash (make-hash))
 
-  (define (common-subexpr-body expr)
+
+  (define final-expr (let common-subexpr-body ([expr start-expr])
     (cond
       [(list? expr)
        (match-define (list op args ...) expr)
@@ -50,9 +51,7 @@
                expr-name))
            `(,op ,@(for/list ([arg args])
                      (common-subexpr-body arg)))))]
-      [else expr]))
-
-  (define final-expr (common-subexpr-body expr))
+      [else expr])))
   (if (empty? intermediates)
     final-expr
     `(let* (,@(reverse intermediates)) ,final-expr)))
@@ -83,6 +82,7 @@
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((i0) (- a a)) (- (+ (+ a a) (+ a a)) i0))))
     '(FPCore (a) (let* ((i0 (- a a)) (i1 (+ a a))) (- (+ i1 i1) i0))))
+
   
 )
 

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -113,10 +113,7 @@
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((x (- a a))) (let ((x (+ a a))) x))))
-    '(FPCore (a) (let ((x (- a a))) (let ((x (+ a a))) x))))
-  
-  
-)
+    '(FPCore (a) (let ((x (- a a))) (let ((x (+ a a))) x)))))
 
 (module+ main
   (require racket/cmdline)

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -1,5 +1,8 @@
 #lang racket
 
+;; TODO: Once the let unroller is implemented we can eliminate more subexpressions.
+;; Right now we don't look inside any let or while statements for eliminating, but once
+;; the unroller is implemented, we can just expand everything for MAXIMUM elimination.
 (require "common.rkt" "fpcore.rkt")
 (module+ test (require rackunit))
 

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -98,15 +98,15 @@
   
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((j0 (+ a a))) j0)))
-    '(FPCore (a) (let* ((j0 (+ a a))) j0)))
+    '(FPCore (a) (let ((j0 (+ a a))) j0)))
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((j0 (+ a a))) (+ (+ a a) j0))))
-    '(FPCore (a) (let* ((i (+ a a))) (+ i i))))
+    '(FPCore (a) (let ((j0 (+ a a))) (+ (+ a a) j0))))
 
   (check-equal?
     (core-common-subexpr-elim '(FPCore (a) (let ((i0 (- a a))) (- (+ (+ a a) (+ a a)) i0))))
-    '(FPCore (a) (let* ((i (- a a)) (i1 (+ a a))) (- (+ i1 i1) i))))
+    '(FPCore (a) (let ((i0 (- a a))) (- (+ (+ a a) (+ a a)) i0))))
   
   
 )

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -55,7 +55,7 @@
   (define final-expr (common-subexpr-body expr))
   (if (empty? intermediates)
     final-expr
-    `(let (,@(reverse intermediates)) ,final-expr)))
+    `(let* (,@(reverse intermediates)) ,final-expr)))
 
 (module+ test
   (check-equal?

--- a/src/common-subexpr-elim.rkt
+++ b/src/common-subexpr-elim.rkt
@@ -32,7 +32,6 @@
   h1)
 
 (define (add-binding-names expr)
-  (println expr)
   (when (list? expr)
     (match-define (list op bindings bind-body) expr)
     (when (set-member? '(let let* while while*) op)

--- a/tools/common-subexpr-elim.rkt
+++ b/tools/common-subexpr-elim.rkt
@@ -32,7 +32,6 @@
 (define (common-subexpr-elim cs-hash expr)
   (define intermediates '())
   (define name-hash (make-hash))
-  (println cs-hash)
 
   (define (common-subexpr-body expr)
     (cond

--- a/tools/common-subexpr-elim.rkt
+++ b/tools/common-subexpr-elim.rkt
@@ -1,0 +1,74 @@
+#lang racket
+
+(require "common.rkt" "fpcore.rkt")
+
+(provide core-common-subexpr-elim)
+
+(define (core-common-subexpr-elim prog)
+  (match-define (list 'FPCore (list args ...) props ... body) prog)
+  (define cs-hash (count-common-subexpr body))
+  (define cse-body (common-subexpr-elim cs-hash body))
+  `(FPCore ,args ,@props ,cse-body))
+
+(define (combine-common-subexpr-hash h1 h2)
+  (for ([(k v) (in-hash h2)])
+    (if (hash-has-key? h1 k)
+      (hash-set! h1 k #t)
+      (hash-set! h1 k v)))
+  h1)
+
+(define (count-common-subexpr expr)
+  (cond 
+    [(list? expr)
+     (match-define (list op args ...) expr)
+     (if (eq? op '!)
+       (count-common-subexpr (last args))
+       (let ([cs-hash (make-hash (list (cons expr #f)))])
+         (for ([e args])
+           (combine-common-subexpr-hash cs-hash (count-common-subexpr e)))
+         cs-hash))]
+    [else (make-hash)]))
+
+(define (common-subexpr-elim cs-hash expr)
+  (define intermediates '())
+  (define name-hash (make-hash))
+  (println cs-hash)
+
+  (define (common-subexpr-body expr)
+    (cond
+      [(list? expr)
+       (match-define (list op args ...) expr)
+       (if (eq? op '!)
+         (list op (take args (sub1 (length args)))
+                  (common-subexpr-body (last args)))
+         ;; returns #f if subexpr doesn't appear more than once
+         (let ([elimed-exprs (for/list ([arg args])
+                               (common-subexpr-body arg))])
+           (if (hash-ref cs-hash expr #f)
+             (if (hash-has-key? name-hash expr)
+               (hash-ref name-hash expr)
+               (let* ([expr-name (string->symbol
+                                   (format "i~a" (hash-count name-hash)))]
+                      [fixed-expr (cons op elimed-exprs)])
+                 (hash-set! name-hash expr expr-name)
+                 (set! intermediates (cons (list expr-name fixed-expr)
+                                           intermediates))
+                 expr-name))
+             `(,op ,@(for/list ([arg args])
+                       (common-subexpr-body arg))))))]
+      [else expr]))
+
+  (define final-expr (common-subexpr-body expr))
+  (if (empty? intermediates)
+    final-expr
+    `(let (,@(reverse intermediates)) ,final-expr)))
+
+(module+ main
+  (require racket/cmdline)
+
+  (command-line
+   #:program "common-subexpr-elim.rkt"
+   #:args ()
+   (port-count-lines! (current-input-port))
+   (for ([expr (in-port (curry read-fpcore "stdin"))] [n (in-naturals)])
+     (printf "~a\n" (core-common-subexpr-elim expr)))))


### PR DESCRIPTION
This change adds a common subexpression eliminator for `FPCore`s. This will take all common subexpressions that appear more than once in the input `FPCore` and extract them out to a top-level `let` binding which will be in the output `FPCore`.