### PR TITLE
Common test structure for C/JS and common supported struct for C/JS/Go compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ core2fptaylor_prec = binary16 binary32 binary64 binary128
 core2fptaylor_unsupported_ops = "atan2" "cbrt" "ceil" "copysign" "erf" "erfc" "exp2" "expm1" "fdim" "floor" "fmod" "hypot" "if" "let*" "lgamma" "log10" "log1p" "log2" "nearbyint" "pow" "remainder" "round" "tgamma" "trunc" "while" "while*"
 
 core2js_prec = binary64
-core2js_unsupported_ops = "fma" "!=" "isfinite" "isnormal" "signbit" "exp2" "erf" "erfc" "tgamma" "lgamma" "fmod" "remainder" "fdim" "copysign" "nearbyint"
+core2js_unsupported_ops = "fma" "isfinite" "isnormal" "signbit" "exp2" "erf" "erfc" "tgamma" "lgamma" "fmod" "remainder" "fdim" "copysign" "nearbyint"
 
 core2smtlib2_prec = binary32 binary64
 core2smtlib2_unsupported_ops = "while*" "let*" "while" "!=" "exp" "exp2" "expm1" "log" "log10" "log2" "log1p" "pow" "cbrt" "hypot" "sin" "cos" "tan" "asin" "acos" "atan" "atan2" "sinh" "cosh" "tanh" "asinh" "acosh" "atanh" "erf" "erfc" "tgamma" "lgamma" "ceil" "floor" "fmod" "fdim" "copysign" "isfinite"
@@ -42,10 +42,10 @@ else
 	$(warning skipping fptaylor sanity tests; unable to find fptaylor)
 endif
 
+#	| $(FILTER) not-operators $(core2js_unsupported_ops)
 js-sanity:
 ifneq (, $(shell which node))
 	cat tests/sanity*.fpcore | $(FILTER) precision $(core2js_prec) \
-	| $(FILTER) not-operators $(core2js_unsupported_ops) \
 	| racket infra/test-core2js.rkt --repeat 1
 else
 	$(warning skipping javascript sanity tests; unable to find node)

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,8 @@ all: testsetup sanity test setup
 
 FILTER = racket infra/filter.rkt
 
-core2c_prec = binary32 binary64
-
 core2fptaylor_prec = binary16 binary32 binary64 binary128
 core2fptaylor_unsupported_ops = "atan2" "cbrt" "ceil" "copysign" "erf" "erfc" "exp2" "expm1" "fdim" "floor" "fmod" "hypot" "if" "let*" "lgamma" "log10" "log1p" "log2" "nearbyint" "pow" "remainder" "round" "tgamma" "trunc" "while" "while*"
-
-core2js_prec = binary64
 
 core2smtlib2_prec = binary32 binary64
 core2smtlib2_unsupported_ops = "while*" "let*" "while" "!=" "exp" "exp2" "expm1" "log" "log10" "log2" "log1p" "pow" "cbrt" "hypot" "sin" "cos" "tan" "asin" "acos" "atan" "atan2" "sinh" "cosh" "tanh" "asinh" "acosh" "atanh" "erf" "erfc" "tgamma" "lgamma" "ceil" "floor" "fmod" "fdim" "copysign" "isfinite"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ core2fptaylor_prec = binary16 binary32 binary64 binary128
 core2fptaylor_unsupported_ops = "atan2" "cbrt" "ceil" "copysign" "erf" "erfc" "exp2" "expm1" "fdim" "floor" "fmod" "hypot" "if" "let*" "lgamma" "log10" "log1p" "log2" "nearbyint" "pow" "remainder" "round" "tgamma" "trunc" "while" "while*"
 
 core2js_prec = binary64
-core2js_unsupported_ops = "fma" "isfinite" "isnormal" "signbit" "exp2" "erf" "erfc" "tgamma" "lgamma" "fmod" "remainder" "fdim" "copysign" "nearbyint"
 
 core2smtlib2_prec = binary32 binary64
 core2smtlib2_unsupported_ops = "while*" "let*" "while" "!=" "exp" "exp2" "expm1" "log" "log10" "log2" "log1p" "pow" "cbrt" "hypot" "sin" "cos" "tan" "asin" "acos" "atan" "atan2" "sinh" "cosh" "tanh" "asinh" "acosh" "atanh" "erf" "erfc" "tgamma" "lgamma" "ceil" "floor" "fmod" "fdim" "copysign" "isfinite"
@@ -42,7 +41,6 @@ else
 	$(warning skipping fptaylor sanity tests; unable to find fptaylor)
 endif
 
-#	| $(FILTER) not-operators $(core2js_unsupported_ops)
 js-sanity:
 ifneq (, $(shell which node))
 	cat tests/sanity*.fpcore | $(FILTER) precision $(core2js_prec) \
@@ -107,7 +105,7 @@ endif
 js-test:
 ifneq (, $(shell which node))
 	cat benchmarks/*.fpcore tests/test*.fpcore | $(FILTER) precision $(core2js_prec) \
-	| $(FILTER) not-operators $(core2js_unsupported_ops) $(known_inaccurate) \
+	| $(FILTER) not-operators $(known_inaccurate) \
 	| racket infra/test-core2js.rkt --error 150
 else
 	$(warning skipping javascript tests; unable to find node)

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,7 @@ known_inaccurate = "round" "isnormal" "fmod" "remainder"
 
 c-sanity:
 ifneq (, $(shell which $(CC)))
-	cat tests/sanity*.fpcore | $(FILTER) precision $(core2c_prec) \
-	| $(FILTER) not-operators $(core2c_unsupported_ops) \
-	| racket infra/test-core2c.rkt --repeat 1
+	cat tests/sanity*.fpcore | racket infra/test-core2c.rkt --repeat 1
 else
 	$(warning skipping C sanity tests; unable to find C compiler $(CC))
 endif
@@ -42,8 +40,7 @@ endif
 
 js-sanity:
 ifneq (, $(shell which node))
-	cat tests/sanity*.fpcore | $(FILTER) precision $(core2js_prec) \
-	| racket infra/test-core2js.rkt --repeat 1
+	cat tests/sanity*.fpcore | racket infra/test-core2js.rkt --repeat 1
 else
 	$(warning skipping javascript sanity tests; unable to find node)
 endif
@@ -83,8 +80,7 @@ raco-test:
 
 c-test:
 ifneq (, $(shell which $(CC)))
-	cat benchmarks/*.fpcore tests/test*.fpcore | $(FILTER) precision $(core2c_prec) \
-	| $(FILTER) not-operators $(core2c_unsupported_ops) $(known_inaccurate) \
+	cat benchmarks/*.fpcore tests/test*.fpcore | $(FILTER) not-operators $(known_inaccurate) \
 	| racket infra/test-core2c.rkt --error 3
 else
 	$(warning skipping C tests; unable to find C compiler $(CC))
@@ -103,8 +99,7 @@ endif
 
 js-test:
 ifneq (, $(shell which node))
-	cat benchmarks/*.fpcore tests/test*.fpcore | $(FILTER) precision $(core2js_prec) \
-	| $(FILTER) not-operators $(known_inaccurate) \
+	cat benchmarks/*.fpcore tests/test*.fpcore | $(FILTER) not-operators $(known_inaccurate) \
 	| racket infra/test-core2js.rkt --error 150
 else
 	$(warning skipping javascript tests; unable to find node)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: testsetup sanity test setup
 FILTER = racket infra/filter.rkt
 
 core2c_prec = binary32 binary64
-core2c_unsupported_ops =
 
 core2fptaylor_prec = binary16 binary32 binary64 binary128
 core2fptaylor_unsupported_ops = "atan2" "cbrt" "ceil" "copysign" "erf" "erfc" "exp2" "expm1" "fdim" "floor" "fmod" "hypot" "if" "let*" "lgamma" "log10" "log1p" "log2" "nearbyint" "pow" "remainder" "round" "tgamma" "trunc" "while" "while*"

--- a/export.rkt
+++ b/export.rkt
@@ -56,16 +56,12 @@
 
    (define-values (header export footer supported)
      (match extension
-       ["fptaylor" (values "" (curry core->fptaylor #:inexact-scale (*scale*)) "" 
-          (supported-list (unsupported-ops->supported '()) (unsupported-consts->supported '()) '(binary16 binary32 binary64 binary128)))]
-       [(or "gappa" "g") (values "" (curry core->gappa #:rel-error (*rel-error*)) "" 
-          (supported-list (unsupported-ops->supported '()) (unsupported-consts->supported '()) '(binary32 binary64 binary128)))]
-       ["scala" (values (format scala-header (*namespace*)) core->scala scala-footer
-          (supported-list (unsupported-ops->supported '()) (unsupported-consts->supported '()) '(binary32 binary64)))]
-       [(or "smt" "smt2" "smtlib" "smtlib2") (values "" core->smtlib2 "" 
-          (supported-list (unsupported-ops->supported '()) (unsupported-consts->supported '()) '(binary32 binary64)))]
-       ["sollya" (values "" core->sollya "" (supported-list (unsupported-ops->supported '()) (unsupported-consts->supported '()) '(binary32 binary64)))]
-       ["wls" (values "" core->wls "" (supported-list (unsupported-ops->supported '()) (unsupported-consts->supported '()) '(binary32 binary64)))]
+       ["fptaylor" (values "" (curry core->fptaylor #:inexact-scale (*scale*)) "" (supported-list (invert-op-list '()) (invert-const-list '()) '(binary16 binary32 binary64 binary128)))]
+       [(or "gappa" "g") (values "" (curry core->gappa #:rel-error (*rel-error*)) "" (supported-list (invert-op-list '()) (invert-const-list '()) '(binary32 binary64 binary128)))]
+       ["scala" (values (format scala-header (*namespace*)) core->scala scala-footer (supported-list (invert-op-list '()) (invert-const-list '()) '(binary32 binary64)))]
+       [(or "smt" "smt2" "smtlib" "smtlib2") (values "" core->smtlib2 "" (supported-list (invert-op-list '()) (invert-const-list '()) '(binary32 binary64)))]
+       ["sollya" (values "" core->sollya "" (supported-list (invert-op-list '()) (invert-const-list '()) '(binary32 binary64)))]
+       ["wls" (values "" core->wls "" (supported-list (invert-op-list '()) (invert-const-list '()) '(binary32 binary64)))]
        [#f (raise-user-error "Please specify an output language (using the --lang flag)")]
        [_
         (apply values
@@ -84,7 +80,7 @@
    (for ([core (in-port (curry read-fpcore (if (equal? in-file "-") "stdin" in-file)) input-port)] [n (in-naturals)])
      (unless (valid-core core supported)
        (raise-user-error (format "Sorry, the *.~a exporter does not support ~a" extension
-          (string-join (map ~a (set-intersect (operators-in core) (supported-ops->unsupported(supported-list-ops supported)))) 
+          (string-join (map ~a (set-intersect (operators-in core) (invert-op-list (supported-list-ops supported)))) 
                         ", "))))
      (fprintf output-port "~a\n" (export core (format "ex~a" n))))
    (unless (*bare*) (fprintf output-port (footer)))))

--- a/export.rkt
+++ b/export.rkt
@@ -74,6 +74,8 @@
                    (compiler-unsupported compiler)))
            (raise-user-error "Unsupported output language" (*lang*))))]))
 
+   (if (and (equal? extension "js") (*runtime*)) (js-runtime (*runtime*)) (void))
+
    (port-count-lines! input-port)
    (unless (*bare*) (fprintf output-port (header (*namespace*))))
    (for ([core (in-port (curry read-fpcore (if (equal? in-file "-") "stdin" in-file)) input-port)] [n (in-naturals)])

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -1,14 +1,9 @@
 #lang racket
 
 (require math/flonum)
-(require "test-common.rkt" "../src/common.rkt" "../src/core2c.rkt" "../src/fpcore.rkt")
+(require "test-common.rkt" "test-imperative.rkt" "../src/core2c.rkt")
 
-(define tests-to-run (make-parameter 10))
-(define test-file (make-parameter "/tmp/test.c"))
-(define fuel (make-parameter 100))
-(define ulps (make-parameter 0))
-
-(define (compile->c prog test-file #:type [type 'binary64])
+(define (compile->c prog type test-file)
   (call-with-output-file test-file #:exists 'replace
     (λ (p)
       (define N (length (second prog)))
@@ -21,7 +16,7 @@
   (system (format "cc ~a -lm -o ~a" test-file c-file))
   c-file)
 
-(define (run<-c exec-name ctx #:type [type 'binary64])
+(define (run<-c exec-name ctx type)
   (define out
     (with-output-to-string
      (λ ()
@@ -38,66 +33,13 @@
      ['binary32 real->single-flonum])
    (string->number out*)))
 
-(define (=* a b)
-  (match (list a b)
-    ['(timeout timeout) true]
-    [else
-     ;; test ranges (e1, e2) (e2, e1) to include negative inputs
-     (or (= a b)
-         (and (nan? a) (nan? b))
-         ;; can only use flonums-between for doubles...
-         (and (double-flonum? a) (double-flonum? b) (<= (abs (flonums-between a b)) (ulps))))]))
+(define c-tester (tester compile->c run<-c))
 
+; cCmmand line
 (module+ main
-  (command-line
-   #:program "test/compiler.rkt"
-   #:once-each
-   ["--fuel" fuel_ "Number of computation steps to allow"
-    (fuel (string->number fuel_))]
-   ["--repeat" repeat_ "Number of times to test each program"
-    (tests-to-run (string->number repeat_))]
-   ["--error" ulps_ "Error, in ULPs, allowed for libc inaccuracies (probably use a value around 3)"
-    (ulps (string->number ulps_))]
-   ["-o" name_ "Name for generated C file"
-    (test-file name_)]
-   #:args ()
-   (let ([error 0])
-     (for ([prog (in-port (curry read-fpcore "stdin") (current-input-port))])
-       (match-define (list 'FPCore (list vars ...) props* ... body) prog)
-       (define-values (_ props) (parse-properties props*))
-       (define type (dict-ref props ':precision 'binary64))
-       (define exec-file (compile->c prog (test-file) #:type type))
-       (define timeout 0)
-       (define results
-         (for/list ([i (in-range (tests-to-run))])
-           (define ctx (for/list ([var vars])
-                         (cons var (match type
-                                     ['binary64 (sample-double)]
-                                     ['binary32 (sample-single)]))))
-           (define evaltor (match type ['binary64 racket-double-evaluator] ['binary32 racket-single-evaluator]))
-           (define out
-             (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
-               [(? real? result)
-                ((match type
-                   ['binary64 real->double-flonum] ['binary32 real->single-flonum])
-                 result)]
-               [(? complex? result)
-                (match type
-                  ['binary64 +nan.0] ['binary32 +nan.f])]
-               ['timeout 'timeout]
-               [(? boolean? result) result]))
-           (when (equal? out 'timeout)
-             (set! timeout (+ timeout 1)))
-           (define out* (if (equal? out 'timeout) 'timeout (run<-c exec-file ctx #:type type)))
-           (list ctx out out*)))
-       (unless (null? results)
-         (printf "~a/~a: ~a~a\n" (count (λ (x) (=* (second x) (third x))) results) (length results)
-                 (dict-ref props ':name body) (match timeout
-                                                [0 ""]
-                                                [1 " (1 timeout)"]
-                                                [_ (format " (~a timeouts)" timeout)]))
-         (set! error (+ error (count (λ (x) (not (=* (second x) (third x)))) results)))
-         (for ([x (in-list results)] #:unless (=* (second x) (third x)))
-           (printf "\t~a ≠ ~a @ ~a\n" (second x) (third x)
-                   (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
-     (exit error))))
+  (parameterize ([*tester* c-tester])
+    (let ([error (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.c")])
+      (if (not (equal? error 0))
+        (printf "Error: ~a" error)
+        (exit 0)))))
+  

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -33,7 +33,15 @@
      ['binary32 real->single-flonum])
    (string->number out*)))
 
-(define c-tester (tester compile->c run<-c c-unsupported))
+(define (c-equality a b ulps)
+  (match (list a b)
+    ['(timeout timeout) true]
+    [else
+      (or (= a b)
+          (and (nan? a) (nan? b))
+          (and (double-flonum? a) (double-flonum? b) (<= (abs (flonums-between a b)) ulps)))]))
+
+(define c-tester (tester compile->c run<-c c-unsupported c-equality))
 
 ; Command line
 (module+ main

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -41,7 +41,7 @@
           (and (nan? a) (nan? b))
           (and (double-flonum? a) (double-flonum? b) (<= (abs (flonums-between a b)) ulps)))]))
 
-(define c-tester (tester compile->c run<-c c-unsupported c-equality))
+(define c-tester (tester compile->c run<-c c-supported c-equality))
 
 ; Command line
 (module+ main

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -28,10 +28,11 @@
       ["inf" "+inf.0"]
       ["-inf" "-inf.0"]
       [x x]))
-  ((match type
-     ['binary64 real->double-flonum]
-     ['binary32 real->single-flonum])
-   (string->number out*)))
+  (cons
+    ((match type
+      ['binary64 real->double-flonum]
+      ['binary32 real->single-flonum])
+    (string->number out*)) out*))
 
 (define (c-equality a b ulps)
   (match (list a b)
@@ -44,6 +45,5 @@
 (define c-tester (tester compile->c run<-c c-supported c-equality))
 
 ; Command line
-(module+ main
-  (parameterize ([*tester* c-tester])
-    (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.c")))
+(module+ main (parameterize ([*tester* c-tester])
+  (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.c")))

--- a/infra/test-core2c.rkt
+++ b/infra/test-core2c.rkt
@@ -33,13 +33,9 @@
      ['binary32 real->single-flonum])
    (string->number out*)))
 
-(define c-tester (tester compile->c run<-c))
+(define c-tester (tester compile->c run<-c c-unsupported))
 
-; cCmmand line
+; Command line
 (module+ main
   (parameterize ([*tester* c-tester])
-    (let ([error (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.c")])
-      (if (not (equal? error 0))
-        (printf "Error: ~a" error)
-        (exit 0)))))
-  
+    (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.c")))

--- a/infra/test-core2js.rkt
+++ b/infra/test-core2js.rkt
@@ -30,7 +30,15 @@
       [(? string->number x) x]))
   (real->double-flonum (string->number out*)))
 
-(define js-tester (tester compile->js run<-js js-unsupported))
+(define (js-equality a b ulps)
+  (match (list a b)
+    ['(timeout timeout) true]
+    [else
+      (or (= a b)
+          (and (nan? a) (nan? b))
+          (<= (abs (flonums-between a b)) ulps))]))
+
+(define js-tester (tester compile->js run<-js js-unsupported js-equality))
 
 ;; TODO: Add types
 (module+ main

--- a/infra/test-core2js.rkt
+++ b/infra/test-core2js.rkt
@@ -1,15 +1,9 @@
 #lang racket
 
 (require math/flonum)
-(require "test-common.rkt" "../src/common.rkt" "../src/compilers.rkt" "../src/core2js.rkt" 
-         "../src/fpcore.rkt" "../src/supported.rkt") 
+(require "test-common.rkt" "test-imperative.rkt" "../src/core2js.rkt")
 
-(define tests-to-run (make-parameter 10))
-(define test-file (make-parameter "/tmp/test.js"))
-(define fuel (make-parameter 100))
-(define ulps (make-parameter 0))
-
-(define (compile->js prog test-file)
+(define (compile->js prog type test-file)
   (call-with-output-file test-file #:exists 'replace
     (λ (p)
        (define N (length (second prog)))
@@ -20,11 +14,11 @@
                              ", "))))
   test-file)
 
-(define (run<-js file-name ctx)
+(define (run<-js exec-name ctx type)
   (define out
     (with-output-to-string
       (λ ()
-         (define file-command (format "node ~a" file-name))
+         (define file-command (format "node ~a" exec-name))
          (system (string-join (cons file-command (map (compose ~a real->double-flonum)
                                                       (dict-values ctx)))
                               " ")))))
@@ -36,62 +30,9 @@
       [(? string->number x) x]))
   (real->double-flonum (string->number out*)))
 
-
-(define (=* a b)
-  (match (list a b)
-    ['(timeout timeout) true]
-    [else
-     ;; test ranges (e1, e2) (e2, e1) to include negative inputs
-     (or (= a b)
-         (and (double-flonum? a) (double-flonum? b)(<= (abs (flonums-between a b)) (ulps)))
-         (and (nan? a) (nan? b)))]))
+(define js-tester (tester compile->js run<-js js-unsupported))
 
 ;; TODO: Add types
 (module+ main
-  (command-line
-   #:program "JS export tester"
-   #:once-each
-   ["--fuel" fuel_ "Number of computation steps to allow"
-    (fuel (string->number fuel_))]
-   ["--repeat" repeat_ "Number of times to test each program"
-    (tests-to-run (string->number repeat_))]
-   ["--error" ulps_ "Error, in ULPs, allowed for node"
-    (ulps (string->number ulps_))]
-   ["-o" name_ "Name for generated js file"
-    (test-file name_)]
-   #:args ()
-   (let ([error 0])       ; loop through tests
-     (for ([prog (in-port (curry read-fpcore "stdin") (current-input-port))]
-        #:when (set-empty? (set-intersect (operators-in prog) js-unsupported))) ; verify valid operators
-       (match-define (list 'FPCore (list vars ...) props* ... body) prog)
-       (define-values (_ props) (parse-properties props*))
-       (define exec-file (compile->js prog (test-file)))
-       (define timeout 0)
-       (define results
-         (for/list ([i (in-range (tests-to-run))])
-           (define ctx (for/list ([var vars])
-                         (cons var (sample-double))))
-           (define evaltor racket-double-evaluator)
-           (define out
-             (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
-               [(? real? result)
-                (real->double-flonum result)]
-               [(? complex? result)
-                +nan.0]
-               ['timeout 'timeout]
-               [(? boolean? result) result]))
-           (when (equal? out 'timeout)
-             (set! timeout (+ timeout 1)))
-           (define out* (if (equal? out 'timeout) 'timeout (run<-js exec-file ctx)))
-           (list ctx out out*)))
-       (unless (null? results)
-         (printf "~a/~a: ~a~a\n" (count (λ (x) (=* (second x) (third x))) results) (length results)
-                 (dict-ref props ':name body) (match timeout
-                                                [0 ""]
-                                                [1 " (1 timeout)"]
-                                                [_ (format " (~a timeouts)" timeout)]))
-         (set! error (+ error (count (λ (x) (not (=* (second x) (third x)))) results)))
-         (for ([x (in-list results)] #:unless (=* (second x) (third x)))
-           (printf "\t~a ≠ ~a @ ~a\n" (second x) (third x)
-                   (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
-     (exit error))))
+  (parameterize ([*tester* js-tester])
+    (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.js")))

--- a/infra/test-core2js.rkt
+++ b/infra/test-core2js.rkt
@@ -18,17 +18,15 @@
   (define out
     (with-output-to-string
       (λ ()
-         (define file-command (format "node ~a" exec-name))
-         (system (string-join (cons file-command (map (compose ~a real->double-flonum)
-                                                      (dict-values ctx)))
-                              " ")))))
+        (define file-command (format "node ~a" exec-name))
+        (system (string-join (cons file-command (map (compose ~a real->double-flonum) (dict-values ctx))) " ")))))
   (define out*
     (match (string-trim out)
       ["NaN" "+nan.0"]
       ["Infinity" "+inf.0"]
       ["-Infinity" "-inf.0"]
       [(? string->number x) x]))
-  (real->double-flonum (string->number out*)))
+  (cons (real->double-flonum (string->number out*)) out*))
 
 (define (js-equality a b ulps)
   (match (list a b)
@@ -41,6 +39,5 @@
 (define js-tester (tester compile->js run<-js js-supported js-equality))
 
 ;; TODO: Add types
-(module+ main
-  (parameterize ([*tester* js-tester])
-    (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.js")))
+(module+ main (parameterize ([*tester* js-tester])
+  (test-imperative (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.js")))

--- a/infra/test-core2js.rkt
+++ b/infra/test-core2js.rkt
@@ -38,7 +38,7 @@
           (and (nan? a) (nan? b))
           (<= (abs (flonums-between a b)) ulps))]))
 
-(define js-tester (tester compile->js run<-js js-unsupported js-equality))
+(define js-tester (tester compile->js run<-js js-supported js-equality))
 
 ;; TODO: Add types
 (module+ main

--- a/infra/test-imperative.rkt
+++ b/infra/test-imperative.rkt
@@ -96,10 +96,7 @@
               [1 " (1 timeout)"]
               [_ (format " (~a timeouts)" timeout)])))
         (set! state (- result-len successful))
-        (for ([x (in-list results)] #:unless (and (not (verbose)) (=* (second x) (car (third x)))))
-          (printf "\t(Expected) ~a ~a (Output) ~a @ ~a\n" 
-              (second x) 
-              (if (=* (second x) (car (third x))) "=" "≠")
-              (if (exact-out) (cdr (third x)) (car (third x)))
-              (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
-    (exit state))))
+        (for ([i (in-naturals 1)] [x (in-list results)] #:unless (and (not (verbose)) (=* (second x) (car (third x)))))
+          (printf "\t~a\t~a\t(Expected) ~a\t(Output) ~a\t(Args) ~a\n" i (if (=* (second x) (car (third x))) "Pass" "Fail") (second x)
+              (if (exact-out) (cdr (third x)) (car (third x))) (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
+    (exit state)))) 

--- a/infra/test-imperative.rkt
+++ b/infra/test-imperative.rkt
@@ -1,0 +1,100 @@
+#lang racket
+
+(require math/flonum)
+(require "test-common.rkt" "../src/common.rkt" "../src/fpcore.rkt" "../src/supported.rkt")
+(provide tester *tester* test-imperative)
+
+; Common test structure
+(struct tester (compile run unsupported))
+(define *tester* (make-parameter #f))
+
+(define (compile-test prog type test-file)
+  ((tester-compile (*tester*)) prog type test-file))
+
+(define (run-test exec-name ctx type)
+  ((tester-run (*tester*)) exec-name ctx type))
+
+(define (unsupported-test)
+  (tester-unsupported (*tester*)))
+
+(define (=* a b)
+  ;m(if (equal? (list a b) '(timeout timeout)))
+  (match (list a b)
+    ['(timeout timeout) true]
+    [else
+     ;; test ranges (e1, e2) (e2, e1) to include negative inputs
+     (or (= a b)
+         (and (nan? a) (nan? b))
+         ;; can only use flonums-between for doubles...
+         (and (double-flonum? a) (double-flonum? b) (<= (abs (flonums-between a b)) (ulps))))]))
+  
+; Test parameters
+
+(define fuel (make-parameter 100))
+(define tests-to-run (make-parameter 10))
+(define ulps (make-parameter 0))
+
+;;; Tester core
+(define (test-imperative argv curr-in-port source test-file)
+  (command-line
+  #:program "C/Go/JS tester"
+  #:once-each
+  ["--fuel" fuel_ "Number of computation steps to allow"
+  (fuel (string->number fuel_))]
+  ["--repeat" repeat_ "Number of times to test each program"
+  (tests-to-run (string->number repeat_))]
+  ["--error" ulps_ "Error, in ULPs, allowed for libc inaccuracies (probably use a value around 3)"
+  (ulps (string->number ulps_))]
+  ["-o" name_ "Name for generated C file"
+  (test-file name_)]
+  #:args ()
+  (let ([state 0] [unsupported (unsupported-test)])
+    (for ([prog (in-port (curry read-fpcore source) curr-in-port)]
+      #:when (set-empty? (set-intersect (operators-in prog) unsupported)))
+      (match-define (list 'FPCore (list vars ...) props* ... body) prog)
+      (define-values (_ props) (parse-properties props*))
+      (define type (dict-ref props ':precision 'binary64))
+      (define exec-file (compile-test prog type test-file))
+      (define timeout 0)
+      (define results  ; run test
+        (for/list ([i (in-range (tests-to-run))])
+          (define ctx (for/list ([var vars])
+          (cons var 
+            (match type
+              ['binary64 (sample-double)]
+              ['binary32 (sample-single)]))))
+          (define evaltor 
+            (match type 
+              ['binary64 racket-double-evaluator] 
+              ['binary32 racket-single-evaluator]))
+          (define out
+            (match ((eval-fuel-expr evaltor (fuel) 'timeout) body ctx)
+              [(? real? result)
+                ((match type
+                  ['binary64 real->double-flonum] 
+                  ['binary32 real->single-flonum])
+                result)]
+              [(? complex? result)
+                (match type
+                  ['binary64 +nan.0]
+                  ['binary32 +nan.f])]
+                  ['timeout 'timeout]
+                  [(? boolean? result)
+                result]))
+          (when (equal? out 'timeout)
+            (set! timeout (+ timeout 1)))
+            (define out* (if (equal? out 'timeout) 'timeout (run-test exec-file ctx type)))
+            (list ctx out out*)))
+
+      (unless (null? results) ; display results
+      (printf "~a/~a: ~a~a\n" (count (λ (x) (=* (second x) (third x))) results) (length results)
+        (dict-ref props ':name body) 
+        (match timeout
+          [0 ""]
+          [1 " (1 timeout)"]
+          [_ (format " (~a timeouts)" timeout)]))
+      (set! state (+ state (count (λ (x) (not (=* (second x) (third x)))) results)))
+      (for ([x (in-list results)] #:unless (=* (second x) (third x)))
+        (printf "\t~a ≠ ~a @ ~a\n" (second x) (third x)
+          (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
+    (exit state))))

--- a/infra/test-imperative.rkt
+++ b/infra/test-imperative.rkt
@@ -4,8 +4,12 @@
 (require "test-common.rkt" "../src/common.rkt" "../src/fpcore.rkt" "../src/supported.rkt")
 (provide tester *tester* test-imperative)
 
+(define fuel (make-parameter 100))
+(define tests-to-run (make-parameter 10))
+(define ulps (make-parameter 0))
+
 ; Common test structure
-(struct tester (compile run unsupported))
+(struct tester (compile run unsupported equality))
 (define *tester* (make-parameter #f))
 
 (define (compile-test prog type test-file)
@@ -18,21 +22,7 @@
   (tester-unsupported (*tester*)))
 
 (define (=* a b)
-  ;m(if (equal? (list a b) '(timeout timeout)))
-  (match (list a b)
-    ['(timeout timeout) true]
-    [else
-     ;; test ranges (e1, e2) (e2, e1) to include negative inputs
-     (or (= a b)
-         (and (nan? a) (nan? b))
-         ;; can only use flonums-between for doubles...
-         (and (double-flonum? a) (double-flonum? b) (<= (abs (flonums-between a b)) (ulps))))]))
-  
-; Test parameters
-
-(define fuel (make-parameter 100))
-(define tests-to-run (make-parameter 10))
-(define ulps (make-parameter 0))
+  ((tester-equality (*tester*)) a b (ulps)))
 
 ;;; Tester core
 (define (test-imperative argv curr-in-port source test-file)

--- a/infra/test-imperative.rkt
+++ b/infra/test-imperative.rkt
@@ -41,9 +41,9 @@
   ["--error" ulps_ "Error, in ULPs, allowed for libc inaccuracies (probably use a value around 3)" (ulps (string->number ulps_))]
   ["--very-verbose" "Very verbose" (verbose #t) (exact-out #t)]
   ["--exact-output" "Exact compiler output" (exact-out #t)]
-  ["-o" name_ "Name for generated C file" (test-file name_)]
-  ["-v" "Verbose" (verbose #t)]
-  ["-q" "Quiet" (quiet #t)]
+  [("-o" "--output") name_ "Name for generated C file" (test-file name_)]
+  [("-v" "--verbose") "Verbose" (verbose #t)]
+  [("-q" "--quiet") "Quiet" (quiet #t)]
   #:args ()
   (if (and (verbose) (quiet)) 
       (error "Verbose and quiet flags cannot be both set") (void))
@@ -97,6 +97,9 @@
               [_ (format " (~a timeouts)" timeout)])))
         (set! state (- result-len successful))
         (for ([x (in-list results)] #:unless (and (not (verbose)) (=* (second x) (car (third x)))))
-          (printf "\t(Expected) ~a ≠ (Output) ~a @ ~a\n" (second x) (if (exact-out) (cdr (third x)) (car (third x)))
-            (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
+          (printf "\t(Expected) ~a ~a (Output) ~a @ ~a\n" 
+              (second x) 
+              (if (=* (second x) (car (third x))) "=" "≠")
+              (if (exact-out) (cdr (third x)) (car (third x)))
+              (string-join (map (λ (x) (format "~a = ~a" (car x) (cdr x))) (first x)) ", ")))))
     (exit state))))

--- a/src/compilers.rkt
+++ b/src/compilers.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "fpcore.rkt")
+(require "fpcore.rkt" "supported.rkt")
 
 (provide
  (contract-out
@@ -9,11 +9,11 @@
      [header (-> string? string?)]
      [export (-> fpcore? string? string?)]
      [footer (-> string?)]
-     [unsupported (listof symbol?)])]
+     [supported supported-list?])]
   [compilers (parameter/c (listof compiler?))])
  define-compiler)
 
-(struct compiler (extensions header export footer unsupported))
+(struct compiler (extensions header export footer supported))
 
 (define compilers (make-parameter '()))
 

--- a/src/compilers.rkt
+++ b/src/compilers.rkt
@@ -2,16 +2,15 @@
 
 (require "fpcore.rkt" "supported.rkt")
 
-(provide
- (contract-out
-  [struct compiler
-    ([extensions (listof string?)]
-     [header (-> string? string?)]
-     [export (-> fpcore? string? string?)]
-     [footer (-> string?)]
-     [supported supported-list?])]
-  [compilers (parameter/c (listof compiler?))])
- define-compiler)
+(provide define-compiler
+  (contract-out
+    [struct compiler
+     ([extensions (listof string?)]
+      [header (-> string? string?)]
+      [export (-> fpcore? string? string?)]
+      [footer (-> string?)]
+      [supported supported-list?])]
+    [compilers (parameter/c (listof compiler?))]))
 
 (struct compiler (extensions header export footer supported))
 

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -1,12 +1,13 @@
 #lang racket
 
 (require "common.rkt" "imperative.rkt" "compilers.rkt")
-(provide c-header core->c)
+(provide c-header core->c c-unsupported)
 
 ;; C
 
 (define c-name (const "c"))
 (define c-header (const "#include <math.h>\n#define TRUE 1\n#define FALSE 0\n\n"))
+(define c-unsupported '()) 
 
 (define/match (type->c-suffix type)
   [("double") ""]
@@ -52,4 +53,4 @@
 
 (define (core->c  prog name) (parameterize ([*lang*  c-language]) (convert-core prog name)))
 
-(define-compiler '("c") c-header core->c (const "") '())
+(define-compiler '("c") c-header core->c (const "") c-unsupported)

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -1,13 +1,16 @@
 #lang racket
 
-(require "common.rkt" "imperative.rkt" "compilers.rkt")
-(provide c-header core->c c-unsupported)
+(require "common.rkt" "compilers.rkt" "imperative.rkt" "supported.rkt")
+(provide c-header core->c c-supported)
 
 ;; C
 
 (define c-name (const "c"))
 (define c-header (const "#include <math.h>\n#define TRUE 1\n#define FALSE 0\n\n"))
-(define c-unsupported '()) 
+(define c-supported (supported-list
+   (unsupported-ops->supported '())
+   (unsupported-const->supported '())
+   '(binary32 binary64)))
 
 (define/match (type->c-suffix type)
   [("double") ""]
@@ -52,5 +55,4 @@
 ;;; Exports
 
 (define (core->c  prog name) (parameterize ([*lang*  c-language]) (convert-core prog name)))
-
-(define-compiler '("c") c-header core->c (const "") c-unsupported)
+(define-compiler '("c") c-header core->c (const "") c-supported)

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -8,8 +8,8 @@
 (define c-name (const "c"))
 (define c-header (const "#include <math.h>\n#define TRUE 1\n#define FALSE 0\n\n"))
 (define c-supported (supported-list
-   (unsupported-ops->supported '())
-   (unsupported-consts->supported '())
+   (invert-op-list '())
+   (invert-const-list '())
    '(binary32 binary64)))
 
 (define/match (type->c-suffix type)
@@ -23,8 +23,8 @@
   [('binary80) "long double"]
   [('boolean) "int"])
 
-(define (operator->c type operator)
-  (format "~a~a(~a)" operator (type->c-suffix type) "~a"))
+(define (operator->c type operator args)
+  (format "~a~a(~a)" operator (type->c-suffix type) (string-join args ", ")))
 
 (define (constant->c type expr)
   (match expr

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -9,7 +9,7 @@
 (define c-header (const "#include <math.h>\n#define TRUE 1\n#define FALSE 0\n\n"))
 (define c-supported (supported-list
    (unsupported-ops->supported '())
-   (unsupported-const->supported '())
+   (unsupported-consts->supported '())
    '(binary32 binary64)))
 
 (define/match (type->c-suffix type)

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -46,9 +46,10 @@
            ", ")
           body return))
 
-(define c-language (language c-name c-header type->c operator->c constant->c declaration->c assignment->c function->c))
+(define c-language (language c-name type->c operator->c constant->c declaration->c assignment->c function->c))
 
 ;;; Exports
 
 (define (core->c  prog name) (parameterize ([*lang*  c-language]) (convert-core prog name)))
-(define-compiler '("c") c-header core->c (const "") '(!))
+
+(define-compiler '("c") c-header core->c (const "") '())

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -8,8 +8,8 @@
 (define go-name (const "go"))
 (define go-header (curry format "package ~a\n\nimport \"math\"\n\n"))
 (define go-supported (supported-list
-   (unsupported-ops->supported '())
-   (unsupported-consts->supported '())
+   (invert-op-list '())
+   (invert-const-list '())
    '(binary32 binary64)))
 
 (define/match (type->go type)
@@ -17,17 +17,18 @@
   [('binary32) "float32"]
   [('boolean) "bool"])
 
-(define (operator->go type operator)
-  (match operator
-    [(or 'fabs 'fmax 'fmin 'fdim)
-     (format "math.~a(~a)" (string-titlecase (substring (~a operator) 1)) "~a")]
-    [(or 'isinf 'isnan)
-     (format "math.Is~a(~a)" (string-titlecase (substring (~a operator) 2)) "~a")]
-    [(or 'exp 'exp2 'expm1 'log 'log10 'log2 'log1p 'pow 'sqrt 'cbrt 'hypot
-         'sin 'cos 'tan 'asin 'cos 'atan 'atan2 'sinh 'cosh 'tanh
-         'asinh 'acosh 'atanh 'erf 'erfc 'tgamma 'lgamma 'ceil 'floor
-         'remainder 'copysign 'trunc 'round)
-     (format "math.~a(~a)" (string-titlecase (~a operator)) "~a")]))
+(define (operator->go type operator args)
+  (let ([arg-list (string-join args ", ")])
+    (match operator
+      [(or 'fabs 'fmax 'fmin 'fdim)
+       (format "math.~a(~a)" (string-titlecase (substring (~a operator) 1)) arg-list)]
+      [(or 'isinf 'isnan)
+       (format "math.Is~a(~a)" (string-titlecase (substring (~a operator) 2)) arg-list)]
+      [(or 'exp 'exp2 'expm1 'log 'log10 'log2 'log1p 'pow 'sqrt 'cbrt 'hypot
+           'sin 'cos 'tan 'asin 'cos 'atan 'atan2 'sinh 'cosh 'tanh
+           'asinh 'acosh 'atanh 'erf 'erfc 'tgamma 'lgamma 'ceil 'floor
+           'remainder 'copysign 'trunc 'round)
+       (format "math.~a(~a)" (string-titlecase (~a operator)) arg-list)])))
 
 (define (constant->go type expr)
   (match expr

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -1,12 +1,16 @@
 #lang racket
 
-(require "common.rkt" "imperative.rkt" "compilers.rkt")
+(require "common.rkt" "compilers.rkt" "imperative.rkt" "supported.rkt")
 (provide go-header core->go)
 
 ;; Go
 
 (define go-name (const "go"))
 (define go-header (curry format "package ~a\n\nimport \"math\"\n\n"))
+(define go-supported (supported-list
+   (unsupported-ops->supported '())
+   (unsupported-const->supported '())
+   '(binary32 binary64)))
 
 (define/match (type->go type)
   [('binary64) "float64"]
@@ -62,4 +66,4 @@
 
 (define (core->go prog name) (parameterize ([*lang* go-language]) (convert-core prog name)))
 
-(define-compiler '("go") go-header core->go (const "") '())
+(define-compiler '("go") go-header core->go (const "") go-supported)

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -9,7 +9,7 @@
 (define go-header (curry format "package ~a\n\nimport \"math\"\n\n"))
 (define go-supported (supported-list
    (unsupported-ops->supported '())
-   (unsupported-const->supported '())
+   (unsupported-consts->supported '())
    '(binary32 binary64)))
 
 (define/match (type->go type)

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -56,9 +56,10 @@
           type
           body return))
 
-(define go-language (language go-name go-header type->go operator->go constant->go declaration->go assignment->go function->go))
+(define go-language (language go-name type->go operator->go constant->go declaration->go assignment->go function->go))
 
 ;;; Exports
 
 (define (core->go prog name) (parameterize ([*lang* go-language]) (convert-core prog name)))
-(define-compiler '("go") go-header core->go (const "") '(!))
+
+(define-compiler '("go") go-header core->go (const "") '())

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -1,12 +1,15 @@
 #lang racket
 
 (require "common.rkt" "imperative.rkt" "compilers.rkt")
-(provide js-header core->js)
+(provide core->js js-unsupported)
 
 ;; JS
 
 (define js-name (const "js"))
 (define js-header (const "")) ; empty
+(define js-unsupported '(!= copysign exp2 erf erfc fdim fma fmod isfinite
+                            isnormal lgamma nearbyint remainder signbit tgamma))
+
 (define (type->js type) "var")
 
 (define/match (operator->js type op)
@@ -95,5 +98,4 @@
 
 (define (core->js prog name) (parameterize ([*lang* js-language]) (convert-core prog name)))
 
-(define-compiler '("js") js-header core->js (const "")
-  '(!= copysign exp2 erf erfc fdim fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))
+(define-compiler '("js") js-header core->js (const "") js-unsupported)

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
-(require "common.rkt" "imperative.rkt" "compilers.rkt")
-(provide core->js js-unsupported js-runtime)
+(require "common.rkt" "compilers.rkt" "imperative.rkt" "supported.rkt")
+(provide core->js js-runtime js-supported)
 
 (define js-runtime (make-parameter "Math"))
 
@@ -9,8 +9,10 @@
 
 (define js-name (const "js"))
 (define js-header (const "")) ; empty
-(define js-unsupported '(!= copysign exp2 erf erfc fdim fma fmod isfinite
-                            isnormal lgamma nearbyint remainder signbit tgamma))
+(define js-supported (supported-list
+   (unsupported-ops->supported '(!= copysign exp2 erf erfc fdim fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))
+   (unsupported-const->supported '())
+   '(binary64)))
 
 (define (type->js type) "var")
 
@@ -65,4 +67,4 @@
 ;;; Exports
 
 (define (core->js prog name) (parameterize ([*lang* js-language]) (convert-core prog name)))
-(define-compiler '("js") js-header core->js (const "") js-unsupported)
+(define-compiler '("js") js-header core->js (const "") js-supported)

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -89,9 +89,11 @@
           body 
           return))
 
-(define js-language (language js-name js-header type->js operator->js constant->js decleration->js assignment->js function->js))
+(define js-language (language js-name type->js operator->js constant->js decleration->js assignment->js function->js))
 
 ;;; Exports
 
 (define (core->js prog name) (parameterize ([*lang* js-language]) (convert-core prog name)))
-(define-compiler '("js") js-header core->js (const "") '(!))
+
+(define-compiler '("js") js-header core->js (const "")
+  '(!= copysign exp2 erf erfc fdim fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -11,7 +11,7 @@
 (define js-header (const "")) ; empty
 (define js-supported (supported-list
    (unsupported-ops->supported '(!= copysign exp2 erf erfc fdim fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))
-   (unsupported-const->supported '())
+   (unsupported-consts->supported '())
    '(binary64)))
 
 (define (type->js type) "var")

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -10,20 +10,21 @@
 (define js-name (const "js"))
 (define js-header (const "")) ; empty
 (define js-supported (supported-list
-   (unsupported-ops->supported '(!= copysign exp2 erf erfc fdim fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))
-   (unsupported-consts->supported '())
+   (invert-op-list'(!= copysign exp2 erf erfc fdim fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))
+   (invert-const-list '())
    '(binary64)))
 
 (define (type->js type) "var")
 
-(define (operator->js type op)
-  (match op
-    ['fabs  (format "~a.abs(~a)" (js-runtime) "~a")]
-    ['fmax  (format "~a.max(~a)" (js-runtime) "~a")]
-    ['fmin  (format "~a.min(~a)" (js-runtime) "~a")]
-    ['isinf (format "(~a.abs(~a) === Infinity)" (js-runtime) "~a")]
-    ['isnan "isNaN(~a)"]
-    [_      (format "~a.~a(~a)" (js-runtime) op "~a")]))
+(define (operator->js type op args)
+  (let ([arg-list (string-join args ", ")])
+    (match op
+      ['fabs  (format "~a.abs(~a)" (js-runtime) arg-list)]
+      ['fmax  (format "~a.max(~a)" (js-runtime) arg-list)]
+      ['fmin  (format "~a.min(~a)" (js-runtime) arg-list)]
+      ['isinf (format "(~a.abs(~a) === Infinity)" (js-runtime) arg-list)]
+      ['isnan (format "isNaN(~a)" arg-list)]
+      [_      (format "~a.~a(~a)" (js-runtime) op arg-list)])))
 
 (define/match (constant->js type expr)
   [(_ 'E) "Math.E"]

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -1,7 +1,9 @@
 #lang racket
 
 (require "common.rkt" "imperative.rkt" "compilers.rkt")
-(provide core->js js-unsupported)
+(provide core->js js-unsupported js-runtime)
+
+(define js-runtime (make-parameter "Math"))
 
 ;; JS
 
@@ -12,48 +14,14 @@
 
 (define (type->js type) "var")
 
-(define/match (operator->js type op)
-  [(_ 'fabs) "Math.abs(~a)"]
-  [(_ 'exp) "Math.exp(~a)"]
-  ;[('exp2) "math.pow(2, ~a)"]
-  [(_ 'expm1) "Math.expm1(~a)"]
-  [(_ 'log) "Math.log(~a)"]
-  [(_ 'log10) "Math.log10(~a)"]
-  [(_ 'log2) "Math.log2(~a)"]
-  [(_ 'log1p) "Math.log1p(~a)"]
-  ;[('logb) "math.floor(math.log2(math.abs(~a)))"]
-  [(_ 'pow) "Math.pow(~a)"]
-  [(_ 'sqrt) "Math.sqrt(~a)"]
-  [(_ 'cbrt) "Math.cbrt(~a)"]
-  [(_ 'hypot) "Math.hypot(~a)"]
-  [(_ 'sin) "Math.sin(~a)"]
-  [(_ 'cos) "Math.cos(~a)"]
-  [(_ 'tan) "Math.tan(~a)"]
-  [(_ 'asin) "Math.asin(~a)"]
-  [(_ 'acos) "Math.acos(~a)"]
-  [(_ 'atan) "Math.atan(~a)"]
-  [(_ 'atan2) "Math.atan2(~a)"]
-  [(_ 'sinh) "Math.sinh(~a)"]
-  [(_ 'cosh) "Math.cosh(~a)"]
-  [(_ 'tanh) "Math.tanh(~a)"]
-  [(_ 'asinh) "Math.asinh(~a)"]
-  [(_ 'acosh) "Math.acosh(~a)"]
-  [(_ 'atanh) "Math.atanh(~a)"]
-  ;[('erf) "math.erf(~a)"]
-  ;[('erfc) "1 - math.erf(~a)"] ;; TODO: This implementation has large error for large inputs
-  ;[('tgamma) "math.gamma(~a)"]
-  ;[('lgamma) "math.log(math.gamma(~a))"]
-  [(_ 'ceil) "Math.ceil(~a)"]
-  [(_ 'floor) "Math.floor(~a)"]
-  ;[('remainder) "math.mod(~a, ~a)"]
-  [(_ 'fmax) "Math.max(~a)"]
-  [(_ 'fmin) "Math.min(~a)"]
-  ;[('fdim) "math.max(0, ~a - ~a)"]
-  ;[('copysign) "math.abs(~a) * math.sign(~a)"]
-  [(_ 'trunc) "Math.trunc(~a)"]
-  [(_ 'round) "Math.round(~a)"]
-  [(_ 'isinf) "(Math.abs(~a) === Infinity)"]
-  [(_ 'isnan) "isNaN(~a)"])
+(define (operator->js type op)
+  (match op
+    ['fabs  (format "~a.abs(~a)" (js-runtime) "~a")]
+    ['fmax  (format "~a.max(~a)" (js-runtime) "~a")]
+    ['fmin  (format "~a.min(~a)" (js-runtime) "~a")]
+    ['isinf (format "(~a.abs(~a) === Infinity)" (js-runtime) "~a")]
+    ['isnan "isNaN(~a)"]
+    [_      (format "~a.~a(~a)" (js-runtime) op "~a")]))
 
 (define/match (constant->js type expr)
   [(_ 'E) "Math.E"]

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -65,5 +65,4 @@
 ;;; Exports
 
 (define (core->js prog name) (parameterize ([*lang* js-language]) (convert-core prog name)))
-
 (define-compiler '("js") js-header core->js (const "") js-unsupported)

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -70,7 +70,7 @@
     [(list 'fmax a b)
      (rounded (format "max(~a, ~a)" a b) ctx)]
     [(list 'fmin a b)
-     (rounded (format "min(~a, ~a)" a b) ctx)]
+     (rounded (format "max(~a, ~a)" a b) ctx)]
     [(list 'nearbyint a)
      (let ([rm (round->sollya (dict-ref ctx ':round 'nearestEven))])
        (if (equal? rm "RN")

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -160,14 +160,15 @@
      (expr->sollya body #:names names* #:ctx ctx #:indent indent)]
     [`(if ,cond ,ift ,iff)
      (define test (expr->sollya cond #:names names #:ctx ctx #:indent indent))
-     (define outvar (fix-name (gensym 'temp)))
+     (define outvar (gensym 'temp))
      (printf "~aif (~a) then {\n" indent test)
-     (printf "~a\t~a = ~a;\n" indent outvar
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
              (expr->sollya ift #:names names #:ctx ctx #:indent (format "~a\t" indent)))
      (printf "\n~a} else {\n" indent)
-     (printf "~a\t~a = ~a;\n" indent outvar
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
              (expr->sollya iff #:names names #:ctx ctx #:indent (format "~a\t" indent)))
-     (printf "\n~a};\n" indent) outvar]
+     (printf "\n~a};\n" indent)
+     (fix-name outvar)]
     [`(while ,cond ([,vars ,inits ,updates] ...) ,retexpr)
      (define vars* (map gensym vars))
      (for ([var* vars*] [val inits])
@@ -176,8 +177,8 @@
      (define names*
        (for/fold ([names* names]) ([var vars] [var* vars*])
          (dict-set names* var var*)))
-     (define test-var (fix-name (gensym 'test)))
-     (printf "~a~a = ~a;\n" indent test-var
+     (define test-var (gensym 'test))
+     (printf "~a~a = ~a;\n" indent (fix-name test-var)
              (expr->sollya cond #:names names* #:ctx ctx #:indent indent))
      (printf "~awhile (~a) do {\n" indent test-var)
      (define temp-vars (map gensym vars))
@@ -186,7 +187,7 @@
                (expr->sollya update #:names names* #:ctx ctx #:indent (format "~a\t" indent))))
      (for ([var* vars*] [temp-var temp-vars])
        (printf "~a\t~a = ~a;\n" indent (fix-name var*) (fix-name temp-var)))
-     (printf "~a\t~a = ~a;" indent test-var
+     (printf "~a\t~a = ~a;" indent (fix-name test-var)
              (expr->sollya cond #:names names* #:ctx ctx #:indent (format "~a\t" indent)))
      (printf "\n~a};\n" indent)
      (expr->sollya retexpr #:names names* #:ctx ctx #:indent indent)]
@@ -197,14 +198,14 @@
        (printf "~a~a = ~a;\n" indent (fix-name var*)
                (expr->sollya val #:names names* #:ctx ctx #:indent indent))
        (set! names* (dict-set names* var var*)))
-     (define test-var (fix-name (gensym 'test)))
-     (printf "~a~a = ~a;\n" indent test-var
+     (define test-var (gensym 'test))
+     (printf "~a~a = ~a;\n" indent (fix-name test-var)
              (expr->sollya cond #:names names* #:ctx ctx #:indent indent))
      (printf "~awhile (~a) do {\n" indent test-var)
      (for ([var* vars*] [update updates])
        (printf "~a\t~a = ~a;\n" indent (fix-name var*)
                (expr->sollya update #:names names* #:ctx ctx #:indent (format "~a\t" indent))))
-     (printf "~a\t~a = ~a;" indent test-var
+     (printf "~a\t~a = ~a;" indent (fix-name test-var)
              (expr->sollya cond #:names names* #:ctx ctx #:indent (format "~a\t" indent)))
      (printf "\n~a};\n" indent)
      (expr->sollya retexpr #:names names* #:ctx ctx #:indent indent)]
@@ -212,67 +213,70 @@
      (expr->sollya body #:names names #:ctx (apply hash-set* ctx props) #:indent indent)]
     ;; some operations need special translations
     [`(isnan ,body)
-     (define tempvar (fix-name (gensym 'temp)))
-     (printf "~a~a = ~a;\n" indent tempvar
+     (define tempvar (gensym 'temp))
+     (printf "~a~a = ~a;\n" indent (fix-name tempvar)
              (expr->sollya body #:names names #:ctx ctx #:indent indent))
-     (format "(~a != ~a)" tempvar tempvar)]
+     (format "(~a != ~a)" (fix-name tempvar) (fix-name tempvar))]
     [`(isinf ,body)
-     (define tempvar (fix-name (gensym 'temp)))
-     (printf "~a~a = ~a;\n" indent tempvar
+     (define tempvar (gensym 'temp))
+     (printf "~a~a = ~a;\n" indent (fix-name tempvar)
              (expr->sollya body #:names names #:ctx ctx #:indent indent))
-     (format "(abs(~a) == infty)" tempvar)]
+     (format "(abs(~a) == infty)" (fix-name tempvar))]
     [`(isfinite ,body)
      (define tempvar (gensym 'temp))
-     (printf "~a~a = ~a;\n" indent tempvar
+     (printf "~a~a = ~a;\n" indent (fix-name tempvar)
              (expr->sollya body #:names names #:ctx ctx #:indent indent))
-     (format "(~a == ~a && abs(~a) != infty)" tempvar tempvar tempvar)]
+     (format "(~a == ~a && abs(~a) != infty)" (fix-name tempvar) (fix-name tempvar) (fix-name tempvar))]
     [`(fdim ,a ,b)
-     (define temp_a (fix-name (gensym 'temp_a)))
-     (define temp_b (fix-name (gensym 'temp_b)))
-     (define outvar (fix-name (gensym 'temp)))
-     (printf "~a~a = ~a;\n" indent temp_a
+     (define temp_a (gensym 'temp_a))
+     (define temp_b (gensym 'temp_b))
+     (define outvar (gensym 'temp))
+     (printf "~a~a = ~a;\n" indent (fix-name temp_a)
              (expr->sollya a #:names names #:ctx ctx #:indent indent))
-     (printf "~a~a = ~a;\n" indent temp_b
+     (printf "~a~a = ~a;\n" indent (fix-name temp_b)
              (expr->sollya b #:names names #:ctx ctx #:indent indent))
-     (printf "~aif (~a > ~a) then {\n" indent temp_a temp_b)
-     (printf "~a\t~a = ~a;\n" indent outvar
-             (rounded (format "~a - ~a" temp_a temp_b) ctx))
+     (printf "~aif (~a > ~a) then {\n" indent (fix-name temp_a) (fix-name temp_b))
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
+             (rounded (format "~a - ~a" (fix-name temp_a) (fix-name temp_b)) ctx))
      (printf "\n~a} else {\n" indent)
-     (printf "~a\t~a = ~a;\n" indent outvar (rounded "0" ctx))
-     (printf "\n~a};\n" indent) outvar]
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar) (rounded "0" ctx))
+     (printf "\n~a};\n" indent)
+     (fix-name outvar)]
     [`(copysign ,a ,b)
-     (define temp_a (fix-name (gensym 'temp_a)))
-     (define temp_b (fix-name (gensym 'temp_b)))
-     (define outvar (fix-name (gensym 'temp)))
-     (printf "~a~a = ~a;\n" indent temp_a
+     (define temp_a (gensym 'temp_a))
+     (define temp_b (gensym 'temp_b))
+     (define outvar (gensym 'temp))
+     (printf "~a~a = ~a;\n" indent (fix-name temp_a)
              (expr->sollya a #:names names #:ctx ctx #:indent indent))
-     (printf "~a~a = ~a;\n" indent temp_b
+     (printf "~a~a = ~a;\n" indent (fix-name temp_b)
              (expr->sollya b #:names names #:ctx ctx #:indent indent))
-     (printf "~aif (~a < 0) then {\n" indent temp_b)
-     (printf "~a\t~a = ~a;\n" indent outvar
-             (rounded (format "-abs(~a)" temp_a) ctx))
+     (printf "~aif (~a < 0) then {\n" indent (fix-name temp_b))
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
+             (rounded (format "-abs(~a)" (fix-name temp_a)) ctx))
      (printf "\n~a} else {\n" indent)
-     (printf "~a\t~a = ~a;\n" indent outvar
-             (rounded (format "abs(~a)" temp_a) ctx))
-     (printf "\n~a};\n" indent) outvar]
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
+             (rounded (format "abs(~a)" (fix-name temp_a)) ctx))
+     (printf "\n~a};\n" indent)
+     (fix-name outvar)]
     [`(trunc ,a)
-     (define temp_a (fix-name (gensym 'temp_a)))
-     (define outvar (fix-name (gensym 'temp)))
-     (printf "~a~a = ~a;\n" indent temp_a
+     (define temp_a (gensym 'temp_a))
+     (define outvar (gensym 'temp))
+     (printf "~a~a = ~a;\n" indent (fix-name temp_a)
              (expr->sollya a #:names names #:ctx ctx #:indent indent))
-     (printf "~aif (~a < 0) then {\n" indent temp_a)
-     (printf "~a\t~a = ~a;\n" indent outvar
-             (rounded (format "ceil(~a)" temp_a) ctx))
+     (printf "~aif (~a < 0) then {\n" indent (fix-name temp_a))
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
+             (rounded (format "ceil(~a)" (fix-name temp_a)) ctx))
      (printf "\n~a} else {\n" indent)
-     (printf "~a\t~a = ~a;\n" indent outvar
-             (rounded (format "floor(~a)" temp_a) ctx))
-     (printf "\n~a};\n" indent) outvar]
+     (printf "~a\t~a = ~a;\n" indent (fix-name outvar)
+             (rounded (format "floor(~a)" (fix-name temp_a)) ctx))
+     (printf "\n~a};\n" indent)
+     (fix-name outvar)]
     ;; this will do the wrong thing for negative zero, since sollya doesn't support it
     [`(signbit ,body)
-     (define tempvar (fix-name (gensym 'temp)))
-     (printf "~a~a = ~a;\n" indent tempvar
+     (define tempvar (gensym 'temp))
+     (printf "~a~a = ~a;\n" indent (fix-name tempvar)
              (expr->sollya body #:names names #:ctx ctx #:indent indent))
-     (format "(~a < 0)" tempvar)]
+     (format "(~a < 0)" (fix-name tempvar))]
     ;; most operators can go to application->sollya, which also fixes up a few that need different names
     [(list (? operator? operator) args ...)
      (define args_sollya

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -70,7 +70,7 @@
     [(list 'fmax a b)
      (rounded (format "max(~a, ~a)" a b) ctx)]
     [(list 'fmin a b)
-     (rounded (format "max(~a, ~a)" a b) ctx)]
+     (rounded (format "min(~a, ~a)" a b) ctx)]
     [(list 'nearbyint a)
      (let ([rm (round->sollya (dict-ref ctx ':round 'nearestEven))])
        (if (equal? rm "RN")

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -5,7 +5,7 @@
 
 ;;; Abstraction for different languages
 
-(struct language (name header type operator constant declaration assignment function))
+(struct language (name type operator constant declaration assignment function))
 (define *lang* (make-parameter #f))
 
 (define (convert-operator type operator)

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -1,7 +1,16 @@
 #lang racket
 
 (require "common.rkt")
-(provide language convert-core *lang*)
+(provide convert-core *lang*
+  (contract-out
+    [struct language
+     ([name (-> string?)]
+      [type (-> symbol? string?)]
+      [operator (-> string? symbol? list? string?)]
+      [constant (-> string? any/c string?)]
+      [declaration (-> string? string? any/c string?)]
+      [assignment (-> string? any/c string?)]
+      [function (-> string? string? any/c any/c string? string?)])]))
 
 ;;; Abstraction for different languages
 

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -8,8 +8,8 @@
 (struct language (name type operator constant declaration assignment function))
 (define *lang* (make-parameter #f))
 
-(define (convert-operator type operator)
-  ((language-operator (*lang*)) type operator))
+(define (convert-operator type operator args)
+  ((language-operator (*lang*)) type operator args))
 
 (define (convert-constant type expr)
   ((language-constant (*lang*)) type expr))
@@ -79,7 +79,7 @@
     [(list 'or a ...)
      (format "(~a)" (string-join (map ~a a) " || "))]
     [(list (? operator? f) args ...)
-     (format (convert-operator (convert-type type) operator) (string-join args ", "))]))
+     (convert-operator (convert-type type) operator args)]))
 
 (define (convert-expr expr #:names [names #hash()] #:type [type 'binary64] #:indent [indent "\t"])
   ;; Takes in an expression. Returns an expression and a new set of names

--- a/src/supported.rkt
+++ b/src/supported.rkt
@@ -1,8 +1,7 @@
 #lang racket
 (require "common.rkt" "fpcore.rkt")
 (provide valid-core operators-in constants-in property-values
-  unsupported-ops->supported supported-ops->unsupported
-  unsupported-consts->supported supported-consts->unsupported)
+  invert-op-list invert-const-list)
 
 (provide
   (contract-out
@@ -15,19 +14,11 @@
 
 ; Blacklist <==> Whitelist
 
-(define (unsupported-ops->supported list)
+(define (invert-op-list list)
   (-> (listof symbol?) (listof symbol?))
   (set-subtract (append operators '(if let let* while while*)) list))
 
-(define (supported-ops->unsupported list)
-  (-> (listof symbol?) (listof symbol?))
-  (set-subtract (append operators '(if let let* while while*)) list))
-
-  (define (unsupported-consts->supported list)
-  (-> (listof symbol?) (listof symbol?))
-  (set-subtract constants list))
-
-(define (supported-consts->unsupported list)
+(define (invert-const-list list)
   (-> (listof symbol?) (listof symbol?))
   (set-subtract constants list))
 

--- a/src/supported.rkt
+++ b/src/supported.rkt
@@ -2,7 +2,7 @@
 (require "common.rkt" "fpcore.rkt")
 (provide valid-core operators-in constants-in property-values
   unsupported-ops->supported supported-ops->unsupported
-  unsupported-const->supported supported-const->unsupported)
+  unsupported-consts->supported supported-consts->unsupported)
 
 (provide
   (contract-out
@@ -23,11 +23,11 @@
   (-> (listof symbol?) (listof symbol?))
   (set-subtract (append operators '(if let let* while while*)) list))
 
-  (define (unsupported-const->supported list)
+  (define (unsupported-consts->supported list)
   (-> (listof symbol?) (listof symbol?))
   (set-subtract constants list))
 
-(define (supported-const->unsupported list)
+(define (supported-consts->unsupported list)
   (-> (listof symbol?) (listof symbol?))
   (set-subtract constants list))
 

--- a/tests/sanity-constants.fpcore
+++ b/tests/sanity-constants.fpcore
@@ -1,8 +1,9 @@
-(FPCore
- ()
- :name
- "Test E (1/1)"
- :spec 1.0
+(FPCore 
+ () 
+ :name 
+ "Test E (1/1)" 
+ :spec 
+ 1.0 
  (if (and (< 2.0 E) (< E 3.0)) 1 0))
 
 (FPCore
@@ -92,3 +93,4 @@
  :spec
  1.0
  (if (and (< 0.5 SQRT1_2) (< SQRT1_2 1.0)) 1 0))
+


### PR DESCRIPTION
Main changes:
- Common test structure (C and JS only)
- Struct for supported operators, constants, and precisions (C/Go/JS compiler)
- Invert functions for whitelist -> blacklist and vice versa (operators and constants)
- Function "valid-core", returns true if fpcore is supported by particular compiler
- Test flags
  - "-q or --quiet": No output unless test failure
  - "-v or --verbose": Output regardless of success/failure
  - "--exact-output": Output straight from compiler without conversion to number (useful for Sollya)
  - "--very-verbose": Both verbose and exact-output flags

Minor changes:
  - C, Go, JS now compile operator arguments in their respective files rather than common compiler
  - Makefile no longer uses unsupported or precisions (C and JS only)
  - js-runtime parameter reimplemented (Oops!)
  - Output for testing now better organized

Unusual finds:
  - tests/sanity-operators.rkt: Whenever infra/gen-sanity.rkt is run, the first test "E" gets written to the file in one line (without newline characters). Currently discarding changes every time I run "make sanity test". Cause??