### PR TITLE
Fpcore visitor

### DIFF
--- a/src/canonicalizer.rkt
+++ b/src/canonicalizer.rkt
@@ -1,90 +1,114 @@
 #lang racket
 
-(require "common.rkt" "fpcore.rkt")
+(require "common.rkt" "fpcore.rkt" "fpcore-visitor.rkt")
 (require racket/hash)
-(provide canonicalize-core expr->canon)
+(provide fpcore->canon expr->canon fpcore->condensed expr->condensed)
 
-(define *to-canonicalize* (make-parameter '(:pre :spec)))
-(define *to-propagate* (make-parameter '(:precision :round :math-library)))
+(define (update-ctx ctx props)
+  (let-values ([(_ properties) (parse-properties props)])
+    (hash-union ctx (make-immutable-hash properties)
+                #:combine/key (lambda (k a b) b))))
 
-(define (flatten-context ctx)
-  (apply append (map (match-lambda [(cons prop val) (list prop val)]) (hash->list ctx))))
+(define (annotate expr ctx)
+  (if (hash-empty? ctx)
+      expr
+      `(! ,@(apply append (hash-map ctx list)) ,expr)))
 
-(define (update-ctx ctx updates)
-  (define new-hash (make-immutable-hash updates))
-  (hash-union ctx new-hash #:combine/key (λ (k a b) b)))
+(define (visit-op_/canon visitor operator args #:ctx ctx)
+  (annotate (visit-op_/transform visitor operator args #:ctx ctx) ctx))
 
-(define (expr->canon expr ctx)
-  (match expr
-    [`(let ([,vars ,vals] ...) ,body)
-     (define bindings (for/list ([var vars] [val vals])
-                        (list var (expr->canon val ctx))))
-     (define new-body (expr->canon body ctx))
-     `(let ,bindings ,new-body)]
-    [`(if ,condition ,then-branch ,else-branch)
-      (define new-cond (expr->canon condition ctx))
-      (define new-then (expr->canon then-branch ctx))
-      (define new-else (expr->canon else-branch ctx))
-      `(if ,new-cond ,new-then ,new-else)]
-    [`(while ,condition ([,vars ,inits ,updates] ...) ,return)
-     (define new-cond (expr->canon condition ctx))
-     (define new-loop (for/list ([var vars] [init inits] [update updates])
-       (list var (expr->canon init ctx) (expr->canon update ctx))))
-     (define new-ret (expr->canon return ctx))
-     `(while ,new-cond ,new-loop ,new-ret)]
-    [(? symbol?)
-     expr]
-    [(or (? constant?) (? number?))
-     (if (= (length (hash-keys ctx)) 0)
-       (if (= (inexact->exact (exact->inexact expr)) expr)
-         (exact->inexact expr)
-         expr)
-     `(! ,@(flatten-context ctx) ,expr))]
-    [(list '! props ... body)
-     (define-values (_ properties) (parse-properties props))
-     (expr->canon body (update-ctx ctx properties))]
-    [(list (? operator? operator) args ...)
-     (define new-args (for/list ([arg args])
-                        (expr->canon arg ctx)))
-     (if (= (length (hash-keys ctx)) 0)
-       (cons operator new-args)
-       `(! ,@(flatten-context ctx) ,(cons operator new-args)))]
-    [_ (error 'expr->smt "Unsupported expr ~a" expr)]))
+(define (visit-literal/canon visitor x #:ctx ctx)
+  (annotate (visit-terminal_/transform visitor x #:ctx ctx) ctx))
 
-(define (canonicalize-args args props)
-  (for/list ([arg args])
-    (if (list? arg)
-      (car (canonicalize-args (list (last arg))
-                              (append props (reverse (cdr (reverse (cdr arg)))))))
-      (if (null? props)
-        arg
-        (append (list '!) props (list arg))))))
+(define/transform-expr (expr->canon expr ctx)
+  [(visit-! visitor props body #:ctx ctx)
+   (visit/ctx visitor body (update-ctx ctx props))]
+  [visit-op_ visit-op_/canon]
+  [visit-number visit-literal/canon]
+  [visit-constant visit-literal/canon])
 
-(define (canonicalize-core prog #:name name)
-  (match-define (list 'FPCore (list args ...) props ... body) prog)
+(define (arg->canon arg ctx)
+  (match arg
+    [`(! ,props ... ,s)
+     (annotate s (update-ctx ctx props))]
+    [s (annotate s ctx)]))
+
+(define (keyify sym)
+  (let ([s (symbol->string sym)])
+    (if (equal? (string-ref s 0) #\:)
+        sym
+        (string->symbol (string-append ":" s)))))
+
+(define (fpcore->canon prog
+                       #:to-propagate [to-propagate '(precision round math-library)]
+                       #:to-canonicalize [to-canonicalize '(pre spec)])
+  (match-define `(FPCore (,args ...) ,props ... ,body) prog)
+  (define propagate-keys (map keyify to-propagate))
+  (define canonicalize-keys (map keyify to-canonicalize))
+
   (define-values (_ properties) (parse-properties props))
-  (define propagate-properties (for/list ([prop properties]
-                                          #:when (set-member? (*to-propagate*) (car prop)))
-                                 prop))
-  (define to-canonicalize-properties (for/list ([prop properties]
-                                             #:when (set-member? (*to-canonicalize*) (car prop)))
-                                       prop))
-  (define canonicalized-properties (for/list ([prop to-canonicalize-properties])
-                                     (if (list? prop)
-                                       (cons (car prop) (expr->canon (cadr prop) (make-immutable-hash propagate-properties)))
-                                       (cons (car prop) (cdr prop)))))
-  (define top-level-properties (append canonicalized-properties (set-subtract
-                                                                  properties
-                                                                  propagate-properties
-                                                                  to-canonicalize-properties)))
-  (define propagate-ctx (make-immutable-hash propagate-properties))
-  `(FPCore
-     ,(canonicalize-args args (flatten-context propagate-ctx))
-     ,@(flatten-context (make-immutable-hash top-level-properties))
-     ,(expr->canon body propagate-ctx)))
+  (define ctx (make-immutable-hash
+               (filter (lambda (pr) (set-member? propagate-keys (car pr))) properties)))
+  (define other-properties (filter (lambda (pr) (not (set-member? propagate-keys (car pr)))) properties))
 
+  `(FPCore
+    ,(for/list ([arg args]) (arg->canon arg ctx))
+    ,@(apply append (for/list ([pr other-properties])
+                      (if (set-member? canonicalize-keys (car pr))
+                          (list (car pr) (expr->canon (cdr pr) ctx))
+                          (list (car pr) (cdr pr)))))
+    ,(expr->canon body ctx)))
+
+(define (new-prop? pr ctx)
+  (let ([k (car pr)]
+        [v (cdr pr)])
+    (if (hash-has-key? ctx k)
+        (not (equal? (hash-ref ctx k) v))
+        #t)))
+
+(define (arg->condensed arg ctx)
+  (match arg
+    [`(! ,props ... ,s)
+     (let*-values ([(_ properties) (parse-properties props)]
+                   [(properties*) (filter (curryr new-prop? ctx) properties)])
+       (if (empty? properties*)
+           s
+           `(! ,@(apply append (map (lambda (pr) (list (car pr) (cdr pr))) properties*)) ,s)))]
+    [s s]))
+
+(define/transform-expr (expr->condensed expr ctx)
+  [(visit-! visitor props body #:ctx ctx)
+   (let*-values ([(_ properties) (parse-properties props)]
+                 [(properties*) (filter (curryr new-prop? ctx) properties)]
+                 [(ctx*) (hash-union ctx (make-immutable-hash properties*)
+                                     #:combine/key (lambda (k a b) b))]
+                 [(expr*) (visit/ctx visitor body ctx*)])
+     (if (empty? properties*)
+         expr*
+         `(! ,@(apply append (map (lambda (pr) (list (car pr) (cdr pr))) properties*)) ,expr*)))])
+
+(define (fpcore->condensed prog
+                           #:to-condense [to-condense '(pre spec)])
+  (match-define `(FPCore (,args ...) ,props ... ,body) prog)
+  (define condense-keys (map keyify to-condense))
+
+  (define-values (_ properties) (parse-properties props))
+  (define ctx (make-immutable-hash properties))
+
+  `(FPCore
+    ,(for/list ([arg args]) (arg->condensed arg ctx))
+    ,@(apply append (for/list ([pr properties])
+                      (if (set-member? condense-keys (car pr))
+                          (list (car pr) (expr->condensed (cdr pr) ctx))
+                          (list (car pr) (cdr pr)))))
+    ,(expr->condensed body ctx)))
+
+;; legacy command line interface, only handles canonicalizer
 (module+ main
   (require racket/cmdline)
+
+  (define *to-canonicalize* (make-parameter '(:pre :spec)))
+  (define *to-propagate* (make-parameter '(:precision :round :math-library)))
 
   (define (custom-command-line command-line-args)
     (parse-command-line "canonicalizer" command-line-args
@@ -122,4 +146,4 @@
 
   (port-count-lines! (current-input-port))
   (for ([expr (in-port (curry read-fpcore "stdin"))] [n (in-naturals)])
-    (pretty-write (canonicalize-core expr #:name (format "ex~a" n)))))
+    (pretty-write (fpcore->canon expr #:to-propagate (*to-propagate*) #:to-canonicalize (*to-canonicalize*)))))

--- a/src/fpcore-visitor.rkt
+++ b/src/fpcore-visitor.rkt
@@ -1,0 +1,302 @@
+#lang racket
+
+(require syntax/parse/define
+         (for-syntax racket/syntax)
+         racket/hash)
+
+(require "common.rkt")
+
+;; common visitor object
+
+(struct visitor
+  (visit-expr
+   visit-if
+   visit-let_
+   visit-let
+   visit-let*
+   visit-while_
+   visit-while
+   visit-while*
+   visit-!
+   visit-op_
+   visit-cast
+   visit-op
+   visit-terminal_
+   visit-number
+   visit-constant
+   visit-symbol
+   reduce))
+
+(define-syntax-parser vterm
+  [(vterm vtor ctx (term args ...))
+   #:with accessor (format-id #'term "visitor-~a" #'term)
+   #'((accessor vtor) vtor args ... #:ctx ctx)]
+  [(vterm vtor ctx (term args ...) (term2 args2 ...))
+   #:with accessor (format-id #'term "visitor-~a" #'term)
+   #:with accessor2 (format-id #'term2 "visitor-~a" #'term2)
+   #'(if (accessor vtor)
+         ((accessor vtor) vtor args ... #:ctx ctx)
+         ((accessor2 vtor) vtor args2 ... #:ctx ctx))])
+
+(define (visit-expr visitor expr #:ctx [ctx '()])
+  (match expr
+    [`(if ,cond ,ift ,iff)
+     (vterm visitor ctx (visit-if cond ift iff))]
+    [`(let ([,vars ,vals] ...) ,body)
+     (vterm visitor ctx
+            (visit-let vars vals body)
+            (visit-let_ 'let vars vals body))]
+    [`(let* ([,vars ,vals] ...) ,body)
+     (vterm visitor ctx
+            (visit-let* vars vals body)
+            (visit-let_ 'let* vars vals body))]
+    [`(while ,cond ([,vars ,inits ,updates] ...) ,body)
+     (vterm visitor ctx
+            (visit-while cond vars inits updates body)
+            (visit-while_ 'while cond vars inits updates body))]
+    [`(while* ,cond ([,vars ,inits ,updates] ...) ,body)
+     (vterm visitor ctx
+            (visit-while* cond vars inits updates body)
+            (visit-while_ 'while* cond vars inits updates body))]
+    [`(! ,props ... ,body)
+     (vterm visitor ctx (visit-! props body))]
+    [`(cast ,body)
+     (vterm visitor ctx
+            (visit-cast body)
+            (visit-op_ 'cast (list body)))]
+    [(list (? operator? operator) args ...)
+     (vterm visitor ctx
+            (visit-op operator args)
+            (visit-op_ operator args))]
+    [(? number? n)
+     (vterm visitor ctx
+            (visit-number n)
+            (visit-terminal_ n))]
+    [(? constant? c)
+     (vterm visitor ctx
+            (visit-constant c)
+            (visit-terminal_ c))]
+    [(? symbol? s)
+     (vterm visitor ctx
+            (visit-symbol s)
+            (visit-terminal_ s))]))
+
+(define-syntax-rule (visit vtor arg)
+  ((visitor-visit-expr vtor) vtor arg))
+
+(define-syntax-rule (visit/ctx vtor arg ctx)
+  ((visitor-visit-expr vtor) vtor arg #:ctx ctx))
+
+;; AST transformers
+
+(define (visit-if/transform visitor cond ift iff #:ctx [ctx '()])
+  `(if ,(visit/ctx visitor cond ctx)
+       ,(visit/ctx visitor ift ctx)
+       ,(visit/ctx visitor iff ctx)))
+
+(define (visit-let_/transform visitor let_ vars vals body #:ctx [ctx '()])
+  `(,let_ (,@(for/list ([var vars] [val vals]) (list var (visit/ctx visitor val ctx))))
+          ,(visit/ctx visitor body ctx)))
+
+(define (visit-while_/transform visitor while_ cond vars inits updates body #:ctx [ctx '()])
+  `(,while_ ,(visit/ctx visitor cond ctx)
+            (,@(for/list ([var vars] [init inits] [update updates])
+                 (list var (visit/ctx visitor init ctx) (visit/ctx visitor update ctx))))
+            ,(visit/ctx visitor body ctx)))
+
+(define (visit-!/transform visitor props body #:ctx [ctx '()])
+  `(! ,@props ,(visit/ctx visitor body ctx)))
+
+(define (visit-op_/transform visitor operator args #:ctx [ctx '()])
+  `(,operator ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-terminal_/transform visitor x #:ctx [ctx '()])
+  x)
+
+;; returns the AST unchanged
+(define default-transform-visitor
+  (visitor
+   visit-expr
+   visit-if/transform
+   visit-let_/transform
+   #f
+   #f
+   visit-while_/transform
+   #f
+   #f
+   visit-!/transform
+   visit-op_/transform
+   #f
+   #f
+   visit-terminal_/transform
+   #f
+   #f
+   #f
+   #f))
+
+;; AST reductions
+
+(define (visit-if/reduce visitor cond ift iff #:ctx [ctx '()])
+  ((visitor-reduce visitor)
+   (list (visit/ctx visitor cond ctx)
+         (visit/ctx visitor ift ctx)
+         (visit/ctx visitor iff ctx))))
+
+(define (visit-let_/reduce visitor let_ vars vals body #:ctx [ctx '()])
+  ((visitor-reduce visitor)
+   (append (for/list ([val vals]) (visit/ctx visitor val ctx))
+           (list (visit/ctx visitor body ctx)))))
+
+(define (visit-while_/reduce visitor while_ cond vars inits updates body #:ctx [ctx '()])
+  ((visitor-reduce visitor)
+   (append (list (visit/ctx visitor cond ctx))
+           (for/list ([init inits]) (visit/ctx visitor init ctx))
+           (for/list ([update updates]) (visit/ctx visitor update ctx))
+           (list (visit/ctx visitor body ctx)))))
+
+(define (visit-!/reduce visitor props body #:ctx [ctx '()])
+  ((visitor-reduce visitor) (list (visit/ctx visitor body ctx))))
+
+(define (visit-op_/reduce visitor operator args #:ctx [ctx '()])
+  ((visitor-reduce visitor)
+   (for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-terminal_/reduce visitor x #:ctx [ctx '()])
+  1)
+
+;; counts terminals
+(define default-reduce-visitor
+  (visitor
+   visit-expr
+   visit-if/reduce
+   visit-let_/reduce
+   #f
+   #f
+   visit-while_/reduce
+   #f
+   #f
+   visit-!/reduce
+   visit-op_/reduce
+   #f
+   #f
+   visit-terminal_/reduce
+   #f
+   #f
+   #f
+   (curry apply +)))
+
+;; macro interface for creating visitors
+
+(define-simple-macro (define-expr-visitor default-visitor new-visitor [method impl] ...)
+  (define new-visitor
+    (struct-copy visitor default-visitor
+                 [method impl] ...)))
+
+(define-simple-macro (define-transform-visitor new-visitor [method impl] ...)
+  (define-expr-visitor default-transform-visitor new-visitor [method impl] ...))
+
+(define-simple-macro (define-reduce-visitor new-visitor [method impl] ...)
+  (define-expr-visitor default-reduce-visitor new-visitor [method impl] ...))
+
+;; macro interface for defining expr visiting functions directly
+;; i.e. like define/match, but specifically for FPCore expressions
+
+(begin-for-syntax
+  (define-syntax-class method-clause
+    (pattern [(name args ...) body ...+]
+             #:with impl #'(lambda (args ...) body ...))
+    (pattern [name impl])))
+
+(define-simple-macro (define/visit-expr default-visitor (fname expr ctx)
+                       method:method-clause ...)
+  (begin
+    (define expr-visitor
+      (struct-copy visitor default-visitor
+                   [method.name method.impl] ...))
+    (define (fname expr ctx)
+      (visit/ctx expr-visitor expr ctx))))
+
+(define-simple-macro (define/transform-expr (fname expr ctx) method:method-clause ...)
+  (define/visit-expr default-transform-visitor (fname expr ctx) method ...))
+
+(define-simple-macro (define/reduce-expr (fname expr ctx) method:method-clause ...)
+  (define/visit-expr default-reduce-visitor (fname expr ctx) method ...))
+
+;; quick tests
+
+(module+ test
+  (require rackunit)
+
+  (define es
+    (list
+     '(let ([x (+ a b)]) (+ x a))
+     '(! :precision (float 8 16) (let* ([y (+ a b)] [z PI]) (sin (* y z))))
+     '(let ([x (+ a b)])
+        (if (let ([y (- x 0)]) (== y x))
+            (- x (let ([z a]) z))
+            y))
+     '(while (< a 3)
+        ([a 0.0 (+ a 1.0)]
+         [b 1.0 (* b 2.0)])
+        b)
+     '(while* (<= a 3)
+              ([a 0.0 (+ a 1.0)]
+               [b 0.0 (while* (<= i a)
+                              ([i 0 (+ i 1)]
+                               [x 0.0 (+ x i)])
+                              x)])
+              b)
+     ))
+
+  (for ([e es])
+    (check-equal?
+     e
+     (visit default-transform-visitor e)))
+
+  (check-equal?
+   (for/list ([e es]) (visit default-reduce-visitor e))
+   '(4 5 10 9 16))
+)
+
+
+;; canonicalizer, needs to be moved out to different file
+
+
+(define (visit-!/canon visitor props body #:ctx ctx)
+  (let*-values ([(_ properties) (parse-properties props)]
+                [(ctx*) (hash-union ctx (make-immutable-hash properties)
+                                    #:combine/key (lambda (k a b) b))])
+    (visit/ctx visitor body ctx*)))
+
+(define (canonicalize-expr expr ctx)
+  (if (hash-empty? ctx)
+      expr
+      `(! ,@(apply append (hash-map ctx (lambda (a b) (list a b)))) ,expr)))
+
+(define (visit-op/canon visitor operator args #:ctx ctx)
+  (canonicalize-expr (visit-op_/transform visitor operator args #:ctx ctx) ctx))
+
+(define (visit-const/canon visitor x #:ctx ctx)
+  (canonicalize-expr (visit-terminal_/transform visitor x #:ctx ctx) ctx))
+
+(define-transform-visitor canonicalize-visitor
+  [visit-! visit-!/canon]
+  [visit-op_ visit-op/canon]
+  [visit-number visit-const/canon]
+  [visit-constant visit-const/canon])
+
+(define/transform-expr (expr->canon expr ctx)
+  [(visit-! visitor props body #:ctx ctx)
+   (let*-values ([(_ properties) (parse-properties props)]
+                 [(ctx*) (hash-union ctx (make-immutable-hash properties)
+                                     #:combine/key (lambda (k a b) b))])
+     (visit/ctx visitor body ctx*))]
+  [(visit-op_ visitor operator args #:ctx ctx)
+   (canonicalize-expr (visit-op_/transform visitor operator args #:ctx ctx) ctx)]
+  [(visit-number visitor x #:ctx ctx)
+   (canonicalize-expr (visit-terminal_/transform visitor x #:ctx ctx) ctx)]
+  [(visit-constant visitor x #:ctx ctx)
+   (canonicalize-expr (visit-terminal_/transform visitor x #:ctx ctx) ctx)])
+
+canonicalize-visitor
+expr->canon


### PR DESCRIPTION
Add a reusable visitor template to make it easier to write some FPCore AST passes and analyses. Also use it to implement new annotation canonicalizer and condenser, and provide support for them from transform.rkt.