### PR TITLE
Cleanup exporting and test generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,12 +172,12 @@ tools-test: export-test transform-test toolserver-test evaluate-test
 test: c-test js-test go-test smtlib2-test sollya-test wls-test cml-test fptaylor-test daisy-test export-test transform-test toolserver-test evaluate-test raco-test 
 
 testsetup:
-	raco make infra/filter.rkt infra/gen-expr.rkt \
+	raco make infra/filter.rkt \
 		infra/test-core2c.rkt infra/test-core2fptaylor.rkt infra/test-core2js.rkt infra/test-core2go.rkt infra/test-core2smtlib2.rkt infra/test-core2sollya.rkt \
 		infra/test-core2wls.rkt infra/test-core2cml.rkt infra/test-core2scala.rkt
 
 setup:
-	raco make export.rkt transform.rkt toolserver.rkt evaluate.rkt 
+	raco make main.rkt export.rkt transform.rkt toolserver.rkt evaluate.rkt 
 
 clean:
 	$(RM) -r library tmp log

--- a/infra/core2json.rkt
+++ b/infra/core2json.rkt
@@ -39,7 +39,7 @@
    prop-hash
    'arguments (map ~pp args)
    'body (~pp body)
-   'operators (map ~pp (operators-in core))
+   'operators (map ~pp (set->list (operators-in core)))
    'core (~pp core)
    'core_fptaylor core-fptaylor))
 

--- a/infra/gen-expr.rkt
+++ b/infra/gen-expr.rkt
@@ -324,11 +324,9 @@
   (for/list ([(prop name) (in-dict (apply dict-set* '() props))])
     (format "~a ~a" prop name)))
 
-(define (pretty-expr-helper expr) ; don't call pretty-format twice
-  (define/transform-expr (pretty-ify expr ctx)
-    [visit-! (λ (vtor props body #:ctx ctx)
-                `(! ,@(pretty-props props) ,(visit/ctx vtor body ctx)))])
-  (pretty-ify expr '()))
+(define/transform-expr (pretty-expr-helper expr) ; don't call pretty-format twice
+  [(visit-! vtor props body)
+   `(! ,@(pretty-props props) ,(visit vtor body))])
 
 (define (pretty-expr expr)
   (pretty-format (pretty-expr-helper expr) #:mode 'display))

--- a/infra/gen-expr.rkt
+++ b/infra/gen-expr.rkt
@@ -7,9 +7,11 @@
 (define random-const? (make-parameter #f))
 (define unique-vars (make-parameter #f))
 (define gensym-count (make-parameter 1))
+(define exhaustive? (make-parameter #f))
 
 ;; Move this somewhere better
-(define bool-ops '(< > <= >= == != and or not isfinite isinf isnan isnormal signbit))
+(define bool-ops 
+        '(< > <= >= == != and or not isfinite isinf isnan isnormal signbit))
 
 (define (rand-from-list list)
   (list-ref list (random 0 (length list))))
@@ -53,8 +55,8 @@
       (shuffle (append vars (make-list (- total-terms (length vars)) 'term)))))
 
 ; Returns a random element of li if exhaustive? is true. Else returns the list
-(define (from-list li exhaustive?)
-  (if exhaustive? li (list (rand-from-list li))))
+(define (from-list li)
+  (if (exhaustive?) li (list (rand-from-list li))))
 
 ;; Generates a list of "unique" names
 (define (gensyms count [name 'x] [start (gensym-count)])
@@ -63,7 +65,7 @@
     (string->symbol (format "~a~a" name (+ i start)))))
     
 ;; Generates a list of random constants. Will generate random floats in random mode
-(define (random-consts count consts prec exhaustive?)
+(define (random-consts count consts prec)
   (for/list ([i (in-range count)])
     (if (random-const?)
         (rand-from-list consts) 
@@ -118,33 +120,49 @@
     [_  subexpr])))
 
 ;; All possible expression with assigned terminals
-(define (assign-terminals expr gen-proc exhaustive? [allow-zero? #t]) ; gen-proc takes number of terminal 'names' to produce
+(define (assign-terminals expr gen-proc [allow-zero? #t]) ; gen-proc takes number of terminal 'names' to produce
   (define max-vars (unbound-in-expr expr))
   (define vars* (gen-proc max-vars))    
   (for*/lists (exprs vars)
-     ([free-count (if (unique-vars) (list max-vars)                                       ; for [0, max] or [1, max] variable terminals   
-                      (from-list (if allow-zero? (build-list (add1 max-vars) identity) (build-list max-vars add1)) exhaustive?))]                                           
-      [var-count (if (unique-vars) (list free-count)                                      ; for 0 or [1, free-count] unique variables
-                     (from-list (if (zero? free-count) (list 0) (build-list free-count add1)) exhaustive?))]
-      [terminals (if exhaustive? (remove-duplicates (terminal-combinations (take vars* var-count) free-count max-vars))
-                                 (list (random-terminals (take vars* var-count) max-vars)))])
+     ([free-count 
+        (cond           ; for [0, max] or [1, max] variable terminals 
+          [(unique-vars) (list max-vars)]   
+          [allow-zero? (from-list (build-list (add1 max-vars) identity))]
+          [else (from-list (build-list max-vars add1))])]                               
+      [var-count 
+        (cond           ; for 0 or [1, free-count] unique variables
+          [(unique-vars) (list free-count)]
+          [(zero? free-count) (list 0)]
+          [else (from-list (build-list free-count add1))])]
+      [terminals        ; generate terminal combinations
+        (if (exhaustive?) 
+            (remove-duplicates (terminal-combinations (take vars* var-count) free-count max-vars))
+            (list (random-terminals (take vars* var-count) max-vars)))])
         (values (assign-vars expr terminals) (take vars* var-count))))
 
 ;; All possible expressions with assigned terminals given a set of known variables
-(define (assign-known expr vars exhaustive? [all? #f]) ; all? ensures that no terminals are left unbound
+(define (assign-known expr vars [all? #f]) ; all? ensures that no terminals are left unbound
   (define max-vars (unbound-in-expr expr))
   (cond
     [(zero? max-vars) (list expr)]
     [all?
-      (for/list ([terminals (if exhaustive? (combinationsr vars max-vars) (list (random-terminals (random-vars vars max-vars) max-vars)))])
-        (assign-vars expr terminals))]
+      (for/list 
+        ([terminals (if (exhaustive?) 
+                        (combinationsr vars max-vars) 
+                        (list (random-terminals (random-vars vars max-vars) max-vars)))])
+          (assign-vars expr terminals))]
     [else
-      (for*/list ([free-count (if (unique-vars) (list max-vars) (from-list (build-list max-vars add1) exhaustive?))]
-                  [vars* (if (> (length vars) free-count) (combinations vars free-count) (list vars))]
-                  [terminals (if exhaustive? (remove-duplicates (terminal-combinations vars* free-count max-vars))
-                                             (list (random-terminals vars* max-vars)))])
-        (assign-vars expr terminals))]))
-      
+      (for*/list 
+         ([free-count (if (unique-vars) 
+                          (list max-vars) 
+                          (from-list (build-list max-vars add1)))]
+          [vars* (if (> (length vars) free-count)
+                        (combinations vars free-count)
+                        (list vars))]
+          [terminals (if (exhaustive?) 
+                         (remove-duplicates (terminal-combinations vars* free-count max-vars))
+                         (list (random-terminals vars* max-vars)))])
+            (assign-vars expr terminals))]))
         
 ; Returns a list of integers of size count such that all values are less than depth
 ; and at least one is one less than depth.
@@ -154,23 +172,31 @@
         (for/list ([i (in-range count)]) 
           (if (= i pivot) (sub1 depth) (random 0 depth))))))    
 
-(define (gen-let-vals op vars gen-proc exhaustive?)
+; let value generator for let/let* and while/while*
+(define (gen-let-vals op vars gen-proc)
+; if 'let' or 'while' and exhaustive:
+;   generate combination of expressions, all terminals unassigned
+; else if 'let*' or 'while*' and exhaustive:
+;   generate val expressions for var 1,2,... (these will be different for let*)
+;   and return the cartesian product of these sets
+; else, not exhaustive, return random val expression
   (cond
-    [(and exhaustive? (or (equal? op 'let) (equal? op 'while)))                      ; if let or while and exhaustive:
-      (combinationsr (gen-proc) (length vars))]                                      ; generate combination of expressions, all terminals unassigned
-    [(and exhaustive? (or (equal? op 'let*) (equal? op 'while*)))                    ; else if let* or while* and exhaustive:
-      (let ([lsts (for/list ([i (in-range (length vars))])                           ; generate val expressions for var 1,2,... (these will be different for let*)
+    [(and (exhaustive?) (or (equal? op 'let) (equal? op 'while)))  
+      (combinationsr (gen-proc) (length vars))]                   
+    [(and (exhaustive?) (or (equal? op 'let*) (equal? op 'while*))) 
+      (let ([lsts (for/list ([i (in-range (length vars))])        
                     (for/fold ([comb '()]) ([val (gen-proc)])  
-                      (append comb (assign-known val (take vars i) exhaustive?))))])
-          (apply cartesian-product lsts))]                                          ; return the cartesian product of these sets
-    [(list (for/list ([var vars] [i (in-naturals)])                                 ; else, get random val expressions
-                (first (assign-known (first (gen-proc)) (if (or (equal? op 'let) (equal? op 'while)) '() (take vars i)) exhaustive?))))]))
+                      (append comb (assign-known val (take vars i)))))])
+          (apply cartesian-product lsts))]                        
+    [(list (for/list ([var vars] [i (in-naturals)])                                 
+              (first (assign-known (first (gen-proc)) 
+                                   (if (or (equal? op 'let) (equal? op 'while)) 
+                                       '() 
+                                       (take vars i))))))]))
 
-;;; Generator
-; TODO: stream-based implementation
-
-(define (gen-cond ops gen-proc exhaustive?)
-  (for/fold ([exprs '()]) ([cond (from-list ops exhaustive?)])
+; condition generator
+(define (gen-cond ops gen-proc)
+  (for/fold ([exprs '()]) ([cond (from-list ops)])
    (match cond
     [(or '< '> '<= '>= '== '!=)
      (append exprs
@@ -183,89 +209,107 @@
         `(,cond ,subexpr)))])))
 
 ;; Layer generator
-(define (gen-layer ops depth exhaustive? [allow-cond? #f])
+(define (gen-layer ops depth [allow-cond? #f])
   (cond
     [(> depth 0)
-      (for/fold ([exprs '()]) ([op (from-list (if allow-cond? (filter (curry set-member? bool-ops) ops) (remove* bool-ops ops)) exhaustive?)])
+      (for/fold ([exprs '()]) 
+                ([op (from-list (if allow-cond? (filter (curry set-member? bool-ops) ops) 
+                                                (remove* bool-ops ops)))])
        (match op
         [(or '< '> '<= '>= '== '!= 'isfinite 'isinf 'isnan 'isnormal 'signbit) ; conditionals
          (append exprs
-          (gen-cond (list op) (thunk (gen-layer ops (sub1 depth) exhaustive?)) exhaustive?))]
+          (gen-cond (list op) (curry gen-layer ops (sub1 depth))))]
         ['-*    ; nice solution to unary minus
          (append exprs
-          (for/list ([subexpr (gen-layer ops (sub1 depth) exhaustive?)])
+          (for/list ([subexpr (gen-layer ops (sub1 depth))])
           `(- ,subexpr)))]
         [(or 'fabs 'exp 'exp2 'expm1 'log 'log10 'log2 'log1p 'sqrt 'cbrt 'sin 'cos 'tan 
              'asin 'acos 'atan 'sinh 'cosh 'tanh 'asinh 'acosh 'atanh 'erf 'erfc 'tgamma 'lgamma 
              'ceil 'floor 'trunc 'round 'nearbyint 'cast)
          (append exprs
-          (for/list ([subexpr (gen-layer ops (sub1 depth) exhaustive?)])
+          (for/list ([subexpr (gen-layer ops (sub1 depth))])
           `(,op ,subexpr)))]
         [(or '+ '- '* '/ 'pow 'hypot 'atan2 'fmod 'remainder 'fmax 'fmin 'fdim 'copysign)
          (append exprs
-          (for*/list ([subexpr1 (gen-layer ops (sub1 depth) exhaustive?)]
-                      [subexpr2 (gen-layer ops (sub1 depth) exhaustive?)])
+          (for*/list ([subexpr1 (gen-layer ops (sub1 depth))]
+                      [subexpr2 (gen-layer ops (sub1 depth))])
           `(,op ,subexpr1 ,subexpr2)))]
         ['fma
          (append exprs
-          (for*/list ([subexpr1 (gen-layer ops (sub1 depth) exhaustive?)]
-                      [subexpr2 (gen-layer ops (sub1 depth) exhaustive?)]
-                      [subexpr3 (gen-layer ops (sub1 depth) exhaustive?)])
+          (for*/list ([subexpr1 (gen-layer ops (sub1 depth))]
+                      [subexpr2 (gen-layer ops (sub1 depth))]
+                      [subexpr3 (gen-layer ops (sub1 depth))])
           `(,op ,subexpr1 ,subexpr2 ,subexpr3)))]
         ['if
          (append exprs
           (for*/list ([cond (gen-cond (filter (curry set-member? bool-ops) ops) 
-                                      (thunk (gen-layer ops (random 0 depth) exhaustive?))
-                            exhaustive?)]
-                      [subexpr1 (gen-layer ops (sub1 depth) exhaustive?)]
-                      [subexpr2 (gen-layer ops (sub1 depth) exhaustive?)])
+                                      (curry gen-layer ops (random 0 depth)))]
+                      [subexpr1 (gen-layer ops (sub1 depth))]
+                      [subexpr2 (gen-layer ops (sub1 depth))])
           `(if ,cond ,subexpr1 ,subexpr2)))]
         [(or 'let 'let*)
          (append exprs
           (for/fold ([exprs* '()])
-                    ([body (gen-layer ops (sub1 depth) exhaustive?)]) ; for all possibe body exprs
-            (let-values ([(bodies varss) (assign-terminals body (curryr gensyms 'x (gensym-count))
-                                                           exhaustive? #f)])
-              (append exprs*
-                (for/list ([body* bodies] [vars varss] #:when #t  ; for all possible vals combinations, see 'gen-let-vals'
-                           [vals (gen-let-vals op vars 
-                                               (thunk (gen-layer ops (random 0 depth) exhaustive?))
-                                               exhaustive?)])                     
+                    ([body (gen-layer ops (sub1 depth))]) ; for all possibe body exprs
+            (let-values ([(bodies varss) (assign-terminals 
+                                            body 
+                                            (curryr gensyms 'x (gensym-count))
+                                            #f)])
+              (append exprs*       ; for all possible vals combinations, see 'gen-let-vals'                  
+                (for/list ([body* bodies] [vars varss] #:when #t 
+                           [vals (gen-let-vals op vars (curry gen-layer ops (random 0 depth)))])                  
                   `(,op ,(map list vars vals) ,body*))))))]
         [(or 'while 'while*)
          (append exprs
-          (for*/fold ([exprs* '()])
-                     ([body (gen-layer ops (sub1 depth) exhaustive?)]                                         ; for all possibe body exprs
-                      [cond (gen-cond (filter (curry set-member? bool-ops) ops)                                  ; for all possible conds
-                                      (thunk (gen-layer ops (sub1 depth) exhaustive?)) exhaustive?)])
-            (let*-values ([(bodies varss) (assign-terminals body (curryr gensyms 'x (gensym-count)) exhaustive? #f)])
-              (append exprs*
-                (for/list ([body* bodies] [vars varss] #:when #t                                              ; for all possible vals combinations
-                           [cond* (assign-known cond vars exhaustive?)] #:when #t
-                           [vals (gen-let-vals op vars (thunk (gen-layer ops (random 0 depth) exhaustive?)) exhaustive?)] #:when #t                                                                        
+          (for*/fold ([exprs* '()])   ; for all possibe body exprs, conds
+                     ([body (gen-layer ops (sub1 depth))]
+                      [cond (gen-cond (filter (curry set-member? bool-ops) ops)
+                                      (curry gen-layer ops (sub1 depth)))])
+            (let*-values ([(bodies varss) (assign-terminals 
+                                            body 
+                                            (curryr gensyms 'x (gensym-count))
+                                            #f)])
+              (append exprs*    ; for all possible vals combinations
+                (for/list ([body* bodies] [vars varss] #:when #t 
+                           [cond* (assign-known cond vars)] #:when #t
+                           [vals (gen-let-vals op vars (curry gen-layer ops (random 0 depth)))]
+                                 #:when #t                                                                        
                            [updates 
-                            (if exhaustive?                                                                   ; for all possible update expr combinations
+                            (if (exhaustive?)   ; for all possible update expr combinations
                                 (combinationsr 
-                                  (for/fold ([comb '()]) ([val (gen-layer ops (random 0 depth) exhaustive?)])  
-                                        (append comb (assign-known val vars exhaustive?)))
+                                  (for/fold ([comb '()]) ([val (gen-layer ops (random 0 depth))])  
+                                        (append comb (assign-known val vars)))
                                   (length vars))
-                                (list (for/list ([var vars])                                                  ; else, get random val expressions
-                                            (first (assign-known (first (gen-layer ops (random 0 depth) exhaustive?)) vars exhaustive?)))))])
+                                (list ; else, get random val expressions
+                                  (for/list ([var vars]) 
+                                    (first (assign-known 
+                                              (first (gen-layer ops (random 0 depth)))
+                                              vars)))))])
                       `(,op ,cond* ,(map list vars vals updates) ,body*))))))]
       ))]
     [else (list 'term)]))
 
 ;; Top-level generator
-(define (gen-expr ops precs rnd-modes consts depth number exhaustive? prec? round? allow-cond? [out-proc expr->bare])
+(define (gen-expr ops precs rnd-modes consts depth number
+                  prec? round? allow-cond? [out-proc expr->bare])
   (define i 1)
   (for* ([c (in-range number)]
-         [expr (gen-layer ops depth exhaustive? allow-cond?)] [prec (from-list precs exhaustive?)] [rnd (from-list rnd-modes exhaustive?)])
+         [expr (gen-layer ops depth allow-cond?)] 
+         [prec (from-list precs)] 
+         [rnd (from-list rnd-modes)])
     (let-values ([(exprs* args*)  ; full expr list
-                    (let-values ([(exprs argss) (assign-terminals expr (curryr gensyms 'arg 1) exhaustive?)])
-                      (for/fold ([full-exprs '()] [arg-list '()] #:result (values full-exprs arg-list)) ; iterate through constant combinations
-                                ([expr* exprs] [args argss] #:when #t
-                                 [final (assign-known expr* (if exhaustive? consts (random-consts (unbound-in-expr expr*) consts prec exhaustive?)) exhaustive? #t)])
-                        (values (append full-exprs (list final)) (append arg-list (list args)))))])
+                    (let-values ([(exprs argss) 
+                                    (assign-terminals expr (curryr gensyms 'arg 1))])
+                      (for/fold  ; iterate through constant combinations
+                        ([full-exprs '()] [arg-list '()] #:result (values full-exprs arg-list)) 
+                        ([expr* exprs] [args argss] #:when #t 
+                          [final 
+                            (assign-known expr* 
+                              (if (exhaustive?)  
+                                 consts 
+                                 (random-consts (unbound-in-expr expr*) consts prec)) #t)])
+                        (values (append full-exprs (list final)) 
+                                (append arg-list (list args)))))])
       (for ([expr* exprs*] [args args*])
         (let ([props (append (if prec? (list ':precision prec) '())
                              (if round? (list ':round (rand-from-list rnd-modes)) '())
@@ -321,7 +365,6 @@
 (module+ main
   (define depth 1)
   (define number 1)
-  (define exhaustive? #f)
   (define ops (remove* '(and or not array dim size ref) 
                         (append operators '(-* if let let* while while*))))
   (define consts (append (remove* '(MAXFLOAT HUGE_VAL INFINITY NAN TRUE FALSE) constants)))
@@ -345,7 +388,7 @@
     ["--unique-vars" "If this flag is set to #t, every variable will be unique"
       (unique-vars #t)]
     [("-e" "--exhaustive") "If this flag is set to #t, this program will output a test for every operator, precision, and rounding mode combination"
-      (set! exhaustive? #t)
+      (exhaustive? #t)
       (set! consts '(1.0))] ; simple constant list, very, very simple
     [("-t" "--type") _type "Specifies what to wrap the expressions in. Default is 'test'. Options: 'bare', 'test' 'bool'"
       (cond
@@ -390,8 +433,8 @@
       (set! rnd-modes '(nearestEven))] ; placeholder for loop
 
     #:args ()
-    (parameterize ([pretty-print-columns 200])
-      (when exhaustive? (set! number 1)) ;; override number if exhaustive generation
+    (parameterize ([pretty-print-columns 100])
+      (when (exhaustive?) (set! number 1)) ;; override number if exhaustive generation
       (when (equal? out-proc expr->bare) ;; avoid redudancy when generating bare expressions
         (set! prec? #f)
         (set! precs '(binary64))
@@ -399,6 +442,8 @@
         (set! rnd-modes '(nearestEven)))  
       (when (not (terminal-port? (current-output-port)))
         (fprintf (current-output-port) ";; -*- mode: scheme -*-\n")
-        (fprintf (current-output-port) (if exhaustive? (format ";; Exhaustive at depth ~a\n\n" depth) (format ";; Count: ~a\n\n" number))))
-      (gen-expr ops precs rnd-modes consts depth number exhaustive? prec? round? allow-cond? out-proc))))
+        (fprintf (current-output-port) (if (exhaustive?)
+                                           (format ";; Exhaustive at depth ~a\n\n" depth) 
+                                           (format ";; Count: ~a\n\n" number))))
+      (gen-expr ops precs rnd-modes consts depth number prec? round? allow-cond? out-proc))))
     

--- a/infra/gen-expr.rkt
+++ b/infra/gen-expr.rkt
@@ -358,7 +358,7 @@
 
 ; Test with 'if' statement, returning 1 on success, 0 on failure
 (define (expr->bool-test expr args name props)
-  (displayln (pretty-fpcore `(FPCore ,args ,@props (if ,expr 1.0 0.0))))
+  (displayln (pretty-fpcore `(FPCore ,args ,@props (if ,expr 1 0))))
   (newline))
 
 ;;; Command line

--- a/infra/gen-expr.rkt
+++ b/infra/gen-expr.rkt
@@ -325,11 +325,10 @@
     (format "~a ~a" prop name)))
 
 (define (pretty-expr-helper expr) ; don't call pretty-format twice
-  (define vtor
-    (struct-copy visitor default-transform-visitor
-      [visit-! (λ (vtor props body #:ctx ctx)
-                 `(! ,@(pretty-props props) ,(visit/ctx vtor body ctx)))]))
-  (visit vtor expr))
+  (define/transform-expr (pretty-ify expr ctx)
+    [visit-! (λ (vtor props body #:ctx ctx)
+                `(! ,@(pretty-props props) ,(visit/ctx vtor body ctx)))])
+  (pretty-ify expr '()))
 
 (define (pretty-expr expr)
   (pretty-format (pretty-expr-helper expr) #:mode 'display))

--- a/infra/gen-tests.rkt
+++ b/infra/gen-tests.rkt
@@ -1,9 +1,9 @@
 #lang racket
 
-(require "../src/common.rkt" "../src/fpcore-interpreter.rkt")
+(require "gen-expr.rkt" "../src/common.rkt" "../src/fpcore-interpreter.rkt")
 (provide number-suite->tests constant-suite->tests
          op-suite->tests bool-op-suite->tests)
-
+  
 (define (op->value op args)
   `(,op ,@args))
 
@@ -23,14 +23,17 @@
 
 (define (constant->test test props port)
   (match-define (list constant lower upper) test)
-  (pretty-write (entry->test `(if (and (< ,lower ,constant) (< ,constant ,upper)) 1 0) props constant 1 1) port)
+  (fprintf port 
+          (pretty-fpcore 
+              (entry->test `(if (and (< ,lower ,constant) (< ,constant ,upper)) 1 0) 
+                            props constant 1 1)))
   (fprintf port "\n"))
 
 (define (op->test test props port expr-proc)  ;; expr-proc formats the expression
   (match-define (list op (list args ...)) test)
   (define n (length args))
   (for ([a args] [i (in-naturals)])
-    (pretty-write (entry->test (expr-proc op a) props op (+ i 1) n) port)
+    (fprintf port (pretty-fpcore (entry->test (expr-proc op a) props op (+ i 1) n) port))
     (fprintf port "\n")))
 
 (define (constant-suite->tests suite props test-file)

--- a/infra/gen-tests.rkt
+++ b/infra/gen-tests.rkt
@@ -8,13 +8,13 @@
   `(,op ,@args))
 
 (define (entry->test val props name i n)
-  (let* ([name-props (append (list ':name (format "Test ~a (~a/~a)" name i n)) props)]
+  (let* ([name-props (append (list ':name (format "\"Test ~a (~a/~a)\"" name i n)) props)]
          [test `(FPCore () ,@name-props ,val)]
          [spec (racket-run-fpcore test '())])
     `(FPCore () ,@name-props :spec ,spec ,val)))
 
 (define (entry->arg-test inputs val props name)
-   (let ([name-props (append (list ':name (format "Test ~a (with inputs)" name)) props)])
+   (let ([name-props (append (list ':name (format "\"Test ~a (with inputs)\"" name)) props)])
      `(FPCore ,inputs ,@name-props ,val)))
      
 (define (sanity-suite->tests suite props test-file print-proc) ;; print-proc prints each test
@@ -27,14 +27,14 @@
           (pretty-fpcore 
               (entry->test `(if (and (< ,lower ,constant) (< ,constant ,upper)) 1 0) 
                             props constant 1 1)))
-  (fprintf port "\n"))
+  (fprintf port "\n\n"))
 
 (define (op->test test props port expr-proc)  ;; expr-proc formats the expression
   (match-define (list op (list args ...)) test)
   (define n (length args))
   (for ([a args] [i (in-naturals)])
-    (fprintf port (pretty-fpcore (entry->test (expr-proc op a) props op (+ i 1) n) port))
-    (fprintf port "\n")))
+    (fprintf port (pretty-fpcore (entry->test (expr-proc op a) props op (+ i 1) n)))
+    (fprintf port "\n\n")))
 
 (define (constant-suite->tests suite props test-file)
   (sanity-suite->tests suite props test-file constant->test))

--- a/infra/test-common.rkt
+++ b/infra/test-common.rkt
@@ -163,8 +163,7 @@
                 (values
                     (for/list ([var vars*] [vtype var-types]) (cons var (sample-random vtype)))
                     (use-precond))]
-              [(or (> (length (variables-in-expr body)) 2)                    ; dependent precondition or
-                   (equal? range-table #f) (equal? range-table (make-hash)))  ; failed range table
+              [(or (equal? range-table #f) (equal? range-table (make-hash)))  ; failed range table
                 (sample-by-rejection precond vars* evaltor type)]
               [else     
                 (values                                                       ; else, valid range table

--- a/main.rkt
+++ b/main.rkt
@@ -25,7 +25,8 @@
  "src/supported.rkt"
 
  "infra/core2json.rkt"
- "infra/filter.rkt")
+ "infra/filter.rkt"
+ "infra/gen-expr.rkt")
 
 (provide
  (all-from-out
@@ -54,6 +55,7 @@
 
   "infra/core2json.rkt"
   "infra/filter.rkt"
+  "infra/gen-expr.rkt"
   ))
 
 (module+ main

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -96,8 +96,8 @@
   (if (and (string-prefix? str "(") (string-suffix? str ")"))
       (let loop ([str (substring str 1)])
         (cond
-          [(zero? (string-length str)) (zero? count)] ; empty string
-          [(zero? count) #f] ; not enclosed, not at end of string
+          [(zero? (string-length str)) (zero? count)] ; at end of string
+          [(zero? count) #f] ; no longer enclosed, not at end of string
           [(equal? (string-ref str 0) #\u28) ; (
             (set! count (add1 count))
             (loop (substring str 1))]

--- a/src/common.rkt
+++ b/src/common.rkt
@@ -2,7 +2,8 @@
 
 (provide parse-properties unparse-properties constants operators
          constant? operator? variable? define-by-match dictof property? property
-         hex? hex->racket digits->number syntax-e-rec)
+         hex? hex->racket digits->number syntax-e-rec
+         trim-infix-parens)
 
 (define (property? symb)
   (and (symbol? symb) (string-prefix? (symbol->string symb) ":")))
@@ -87,3 +88,26 @@
 
 (define (digits->number m e b)
   (* m (expt b e)))
+
+;; Returns true if the string (assumed to be infix notation) is enclosed by a matching pair of
+;; parentheses. Note that (a + b) / (c + d) returns false.
+(define (enclosed-by-paren-pair str)
+  (define count 1)
+  (if (and (string-prefix? str "(") (string-suffix? str ")"))
+      (let loop ([str (substring str 1)])
+        (cond
+          [(zero? (string-length str)) (zero? count)] ; empty string
+          [(zero? count) #f] ; not enclosed, not at end of string
+          [(equal? (string-ref str 0) #\u28) ; (
+            (set! count (add1 count))
+            (loop (substring str 1))]
+          [(equal? (string-ref str 0) #\u29) ; )
+            (set! count (sub1 count))
+            (loop (substring str 1))]
+          [else (loop (substring str 1))]))
+      #f))
+     
+(define (trim-infix-parens str)
+  (if (enclosed-by-paren-pair str)
+      (trim-infix-parens (substring str 1 (sub1 (string-length str))))
+      str))

--- a/src/compilers.rkt
+++ b/src/compilers.rkt
@@ -91,7 +91,7 @@
 
 ; Returns the property value stored in the context struct. Returns the value at 
 ; failure otherwise.
-(define (ctx-lookup-prop ctx prop failure)
+(define (ctx-lookup-prop ctx prop [failure #f])
   (dict-ref (compiler-ctx-props ctx) prop failure))
 
 ; Returns the context struct's properties.

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -5,11 +5,12 @@
 (provide c-header core->c c-supported)
 
 (define c-header (const "#include <fenv.h>\n#include <math.h>\n#include <stdint.h>\n#define TRUE 1\n#define FALSE 0\n\n"))
-(define c-supported (supported-list
-  fpcore-ops
-  fpcore-consts
-  '(binary32 binary64 binary80 integer)
-  (invert-round-modes-list '(nearestAway))))
+(define c-supported 
+  (supported-list
+    fpcore-ops
+    fpcore-consts
+    (curry set-member? '(binary32 binary64 binary80 integer))
+    (invert-rnd-mode-proc (curry equal? 'nearestAway))))
 
 (define c-reserved '())  ; Language-specific reserved names (avoid name collisions)
 

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -35,7 +35,7 @@
     ['isfinite  (format "isfinite(~a)" args)]
     ['isnormal  (format "isnormal(~a)" args)]
     ['signbit   (format "signbit(~a)" args)]
-    [_          (format "((~a) ~a~a(~a))" type op (type->c-suffix type) (string-join args ", "))]))
+    [_          (format "~a~a(~a)" op (type->c-suffix type) (string-join args ", "))]))
 
 (define (constant->c props expr)
   (define prec (dict-ref props ':precision 'binary64))
@@ -82,10 +82,10 @@
   (if (equal? rnd-mode 'nearestEven) ; if not 'nearestEven, set round mode, then restore the original mode
       (format "~a ~a(~a) {\n~a\treturn ~a;\n}\n"
               type name (string-join (map (λ (arg) (format "~a ~a" type arg)) args) ", ")
-              body return)
+              body (trim-infix-parens return))
       (format "~a ~a(~a) {\n~a~a\t~a ~a = ~a;\n~a\treturn ~a;\n}\n"    
               type name (string-join (map (λ (arg) (format "~a ~a" type arg)) args) ", ")
-              (round-mode->c rnd-mode "\t") body type ret-var return        
+              (round-mode->c rnd-mode "\t") body type ret-var (trim-infix-parens return)      
               (round-mode->c 'nearestEven "\t") ret-var)))
 
 (define c-language (language "c" operator->c constant->c declaration->c assignment->c

--- a/src/core2cml.rkt
+++ b/src/core2cml.rkt
@@ -4,8 +4,9 @@
 (provide core->cml cml-supported)
 
 (define cml-supported (supported-list
-  (disjoin ieee754-ops (negate (curry equal? 'fma))
-           (curry set-member? '(! if let let* while while* not and or digits)))
+  (disjoin 
+    (conjoin ieee754-ops (negate (curry equal? 'fma)))
+    (curry set-member? '(! if let let* while while* not and or digits)))        
   (curry set-member? '(TRUE FALSE INFINITY NAN))
   (curry equal? 'binary64)
   (curry equal? 'nearestEven))) ; bool
@@ -23,7 +24,7 @@
   (string-set! str 0 (char-downcase (string-ref str 0)))
   str)
 
-(define/match (operator->sml op)
+(define/match (operator->cml op)
   [('==) "Double.="]
   [((or '+ '- '* '/ '> '< '>= '<=)) (format "Double.~a" op)])
 
@@ -31,12 +32,12 @@
   (match (cons operator args)
     [(list '- a) (format "(Double.~~ ~a)" a)]
     [(list (or '== '!= '< '> '<= '>=)) "True"]
-    [(list (or '+ '- '* '/) a b) (format "(~a ~a ~a)" (operator->sml operator) a b)]
+    [(list (or '+ '- '* '/) a b) (format "(~a ~a ~a)" (operator->cml operator) a b)]
     [(list (or '== '< '> '<= '>=) head args ...)
      (format "~a"
              (string-join
               (for/list ([a (cons head args)] [b args])
-                (format "(~a ~a ~a)" (operator->sml operator) a b))
+                (format "(~a ~a ~a)" (operator->cml operator) a b))
               " andalso "))]
     [(list '!= args ...)
       (format "~a"

--- a/src/core2cml.rkt
+++ b/src/core2cml.rkt
@@ -81,7 +81,7 @@
     indent indent body indent)) ; todo fix
 
 (define (if->cml cond ift iff tmp indent)
-  (format "if ~a\n~athen ~a\n~aelse ~a\n"
+  (format "if ~a\n~athen ~a\n~aelse ~a"
           cond indent ift indent iff))
 
 (define (while->cml vars inits cond updates updatevars body loop indent nested)

--- a/src/core2cml.rkt
+++ b/src/core2cml.rkt
@@ -4,10 +4,11 @@
 (provide core->cml cml-supported)
 
 (define cml-supported (supported-list
-   (append (set-subtract ieee754-ops '(fma)) '(! if let let* while while* not and or digits)) 
-  '(TRUE FALSE INFINITY NAN)
-  '(binary64)
-  '(nearestEven))) ; bool
+  (disjoin ieee754-ops (negate (curry equal? 'fma))
+           (curry set-member? '(! if let let* while while* not and or digits)))
+  (curry set-member? '(TRUE FALSE INFINITY NAN))
+  (curry equal? 'binary64)
+  (curry equal? 'nearestEven))) ; bool
 
 (define cml-reserved '()) ; Language-specific reserved names (avoid name collisions)
 

--- a/src/core2fptaylor.rkt
+++ b/src/core2fptaylor.rkt
@@ -3,12 +3,15 @@
 (require "common.rkt" "fpcore-reader.rkt" "fpcore-extra.rkt" "range-analysis.rkt" "supported.rkt")
 (provide core->fptaylor fptaylor-supported)
 
-(define fptaylor-supported (supported-list
-  (invert-op-list '(atan2 cbrt ceil copysign erf erfc exp2 expm1 fdim floor fmod hypot if let* 
-                    lgamma log10 log1p log2 nearbyint pow remainder round tgamma trunc while while*))
-  fpcore-consts
-  '(binary16 binary32 binary64 binary128)
-  '(nearestEven)))
+(define fptaylor-supported 
+  (supported-list
+    (invert-op-proc 
+      (curry set-member?
+             '(atan2 cbrt ceil copysign erf erfc exp2 expm1 fdim floor fmod hypot if let* 
+              lgamma log10 log1p log2 nearbyint pow remainder round tgamma trunc while while*)))
+    fpcore-consts
+    (curry set-member? '(binary16 binary32 binary64 binary128))
+    (curry equal? 'nearestEven)))
 
 (define (fix-name name)
   (string-join

--- a/src/core2gappa.rkt
+++ b/src/core2gappa.rkt
@@ -5,10 +5,10 @@
 
 (define gappa-supported
   (supported-list 
-    (append ieee754-ops '(let not and or)) 
-    '(SQRT2 SQRT1_2 TRUE FALSE)
-    '(binary32 binary64 binary80 binary128)
-    '(nearestEven)))
+    (compose ieee754-ops (curry set-member? '(let not and or)))
+    (curry set-member? '(SQRT2 SQRT1_2 TRUE FALSE))
+    (curry set-member? '(binary32 binary64 binary80 binary128))
+    (curry equal? 'nearestEven)))
 
 (define (fix-name name)
   (string-join

--- a/src/core2gappa.rkt
+++ b/src/core2gappa.rkt
@@ -5,7 +5,7 @@
 
 (define gappa-supported
   (supported-list 
-    (compose ieee754-ops (curry set-member? '(let not and or)))
+    (disjoin ieee754-ops (curry set-member? '(let not and or)))
     (curry set-member? '(SQRT2 SQRT1_2 TRUE FALSE))
     (curry set-member? '(binary32 binary64 binary80 binary128))
     (curry equal? 'nearestEven)))

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -17,11 +17,12 @@
       go-func-header)))
                    
 
-(define go-supported (supported-list
-   (invert-op-list '(isnormal isfinite)) 
-   (invert-const-list '(M_1_PI M_2_PI M_2_SQRTPI SQRT1_2))
-   '(binary64)
-   '(nearestEven)))
+(define go-supported 
+  (supported-list
+    (invert-op-proc (curry set-member? '(isnormal isfinite)))
+    (invert-const-proc (curry set-member? '(M_1_PI M_2_PI M_2_SQRTPI SQRT1_2)))
+    (curry equal? 'binary64)
+    (curry equal? 'nearestEven)))
 
 (define go-reserved '()) ; Language-specific reserved names (avoid name collisions)
 

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -77,7 +77,7 @@
           name 
           (string-join args ", ") 
           body 
-          return))
+          (trim-infix-parens return)))
 
 (define js-language (language "js" operator->js constant->js decleration->js assignment->js round->js (const "") function->js))
 

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -17,11 +17,14 @@
             "function pow(x, y) { if (x == 1.0 && isNaN(y)) { return 1.0; } else { return ~a.pow(x, y); }}\n"))
      '("function fdim(x , y) { if (x != x || y != y) { return NaN; } else if (x > y) { return x - y; } else { return 0; }}\n\n")))))
 
-(define js-supported (supported-list
-   (invert-op-list '(!= copysign exp2 erf erfc fma fmod isfinite isnormal lgamma nearbyint remainder signbit tgamma))
-   fpcore-consts
-   '(binary64)
-   '(nearestEven)))
+(define js-supported 
+  (supported-list
+    (invert-op-proc 
+      (curry set-member? '(!= copysign exp2 erf erfc fma fmod isfinite isnormal   
+                             lgamma nearbyint remainder signbit tgamma)))
+    fpcore-consts
+    (curry equal? 'binary64)
+    (curry equal? 'nearestEven)))
 
 (define js-reserved '())  ; Language-specific reserved names (avoid name collisions)
 

--- a/src/core2scala.rkt
+++ b/src/core2scala.rkt
@@ -12,12 +12,13 @@
 
 (define scala-supported
   (supported-list
-   '(+ - * / sqrt sin cos tan asin acos atan exp log fma      ;; pow has partial support
-     < > <= >= == != and or not
-     if let let* digits !)          ;; benchmarks with if statements break with --mixed-precision flag
-   '(TRUE FALSE)
-   '(binary32 binary64 binary128 binary256)          
-   '(nearestEven)))
+    (curry set-member?
+          '(+ - * / sqrt sin cos tan asin acos atan exp log fma      ;; pow has partial support
+            < > <= >= == != and or not
+            if let let* digits !))   ;; benchmarks with if statements break with --mixed-precision flag
+    (curry set-member? '(TRUE FALSE))
+    (curry set-member? '(binary32 binary64 binary128 binary256))        
+    (curry equal? 'nearestEven)))
 
 (define scala-reserved '())
 

--- a/src/core2smtlib2.rkt
+++ b/src/core2smtlib2.rkt
@@ -4,13 +4,15 @@
 (require "common.rkt" "compilers.rkt" "supported.rkt")
 (provide core->smtlib2 smt-supported rm->smt number->smt)
 
-(define smt-supported (supported-list
-  (invert-op-list '(while* while exp exp2 expm1 log log10 log2 log1p pow cbrt
-                    hypot sin cos tan asin acos atan atan2 sinh cosh tanh asinh acosh 
-                    atanh erf erfc tgamma lgamma ceil floor fmod fdim copysign isfinite))
-  (invert-const-list '(LOG2E LOG10E M_1_PI M_2_PI M_2_SQRTPI))
-  '(binary32 binary64)
-   ieee754-rounding-modes))
+(define smt-supported 
+  (supported-list
+    (invert-op-proc 
+      (curry set-member? '(while* while exp exp2 expm1 log log10 log2 log1p pow cbrt
+                           hypot sin cos tan asin acos atan atan2 sinh cosh tanh asinh acosh 
+                           atanh erf erfc tgamma lgamma ceil floor fmod fdim copysign isfinite)))
+    (invert-const-proc (curry set-member? '(LOG2E LOG10E M_1_PI M_2_PI M_2_SQRTPI)))
+    (curry set-member? '(binary32 binary64))
+    ieee754-rounding-modes))
 
 (define smt-reserved '())  ; Language-specific reserved names (avoid name collisions)
 

--- a/src/core2smtlib2.rkt
+++ b/src/core2smtlib2.rkt
@@ -62,11 +62,12 @@
 ;; However, at least with z3, defining constants in this way does not seem to cause
 ;; any significant issues.
 (define (number->smt x w p rm)
-  (match x
-    [(or +inf.0 +inf.f) (format "(_ +oo ~a ~a)" w p)]
-    [(or -inf.0 -inf.f) (format "(_ -oo ~a ~a)" w p)]
-    [(or +nan.0 +nan.f) (format "(_ NaN ~a ~a)" w p)]
-    [_ (let* ([q (if (single-flonum? x)
+  (cond
+   [(and (infinite? x) (positive? x)) (format "(_ +oo ~a ~a)" w p)]
+   [(and (infinite? x) (negative? x)) (format "(_ -oo ~a ~a)" w p)]
+   [(nan? x) (format "(_ NaN ~a ~a)" w p)]
+   [else 
+      (let* ([q (if (single-flonum? x)
                      ;; Workaround for misbehavior of inexact->exact with single-flonum inputs
                      (inexact->exact (real->double-flonum x))
                      (inexact->exact x))]
@@ -263,7 +264,7 @@
               (format "((_ to_fp ~a ~a) ~a ~a)" max-w max-p (rm->smt (ctx-lookup-prop ctx ':round 'nearestEven)) arg*))))
       (values (application->smt operator args_r ctx (and (equal? w max-w) (equal? p max-p))) w p)] 
 
-    [(list digits m e b) (values (constant->smt (digits->number m e b) ctx) w p)]
+    [(list 'digits m e b) (values (constant->smt (digits->number m e b) ctx) w p)]
     [(? constant?) (values (constant->smt expr ctx) w p)]
     [(? hex?) (values (constant->smt (hex->racket expr) ctx) w p)]
     [(? number?) (values (constant->smt expr ctx) w p)]

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -3,11 +3,13 @@
 (require "common.rkt" "compilers.rkt" "imperative.rkt" "supported.rkt")
 (provide core->sollya sollya-supported sollya-header *sollya-warnings*)
 
-(define sollya-supported (supported-list
-  (invert-op-list '(isnormal tgamma lgamma remainder fmod round cbrt atan2 erf signbit))
-  fpcore-consts
-  '(binary32 binary64 binary80 integer)
-  ieee754-rounding-modes))
+(define sollya-supported 
+  (supported-list
+    (invert-op-proc 
+      (curry set-member? '(isnormal tgamma lgamma remainder fmod round cbrt atan2 erf signbit)))
+    fpcore-consts
+    (curry set-member? '(binary32 binary64 binary80 integer))
+    ieee754-rounding-modes))
 
 (define *sollya-warnings* (make-parameter #t))
 

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -137,7 +137,7 @@
         var-string
         rounding-string
         body
-        return))
+        (trim-infix-parens return)))
 
 (define sollya-language (language "sollya" operator->sollya constant->sollya declaration->sollya assignment->sollya
                                   round->sollya (const "") function->sollya))

--- a/src/core2tex.rkt
+++ b/src/core2tex.rkt
@@ -82,6 +82,12 @@
   [('TRUE)          "\\top"]
   [('FALSE)         "\\perp"])
 
+(define/match (round-mode->tex expr)
+  [('nearestEven)   "RNE"]
+  [('toPositive)    "RTP"]
+  [('toNegative)    "RTN"]
+  [('toZero)        "RTZ"])
+
 (define (operator->tex op args)
   (match op
    ['==         (format "~a = ~a" (first args) (second args))]
@@ -192,19 +198,17 @@
         [`(! ,props ... ,body) 
           (define curr-prec (ctx-lookup-prop ctx ':precision))
           (define curr-rnd (ctx-lookup-prop ctx ':round))
-
           (define ctx* (ctx-update-props ctx props))
           (define body* (texify body ctx* parens loc))
           (define new-prec (ctx-lookup-prop ctx* ':precision curr-prec))
           (define new-rnd (ctx-lookup-prop ctx* ':round curr-rnd))
           (cond
             [(and (not (equal? curr-prec new-prec)) (not (equal? curr-rnd new-rnd)))
-             (format "\\langle ~a \\rangle^{~a \\rightarrow ~a}_{~a \\rightarrow ~a}"
-                     body* new-rnd curr-rnd new-prec curr-prec)]
+             (format "\\left( ~a \\right)_{~a, ~a}" body* (round-mode->tex new-rnd) new-prec)]
             [(not (equal? curr-prec new-prec))
-             (format "\\langle ~a \\rangle_{~a \\rightarrow ~a}" body* new-prec curr-prec)]
+             (format "\\left( ~a \\right)_{~a}" body* new-prec)]
             [(not (equal? curr-rnd new-rnd))
-             (format "\\langle ~a \\rangle^{~a \\rightarrow ~a}" body* new-rnd curr-rnd)]
+             (format "\\left( ~a \\right)_{~a}" body* (round-mode->tex new-rnd))]
             [else body*])]
 
         [(? exact-integer?)

--- a/src/core2tex.rkt
+++ b/src/core2tex.rkt
@@ -5,13 +5,10 @@
 
 (define tex-supported 
   (supported-list
-    (append 
-     '(j0 j1 y0 y1 rint)
-      (invert-op-list '(let let* while while* for for* tensor tensor*
-                       array dim ref size)))
-    '(PI E INFINITY NAN TRUE FALSE)
-    '(binary32 binary64)       ;; TODO: 'any precision' 
-    (invert-round-modes-list '(nearestAway))))
+    (const #t)
+    (curry set-member? '(PI E INFINITY NAN TRUE FALSE))
+    (const #t)
+    ieee754-rounding-modes))
 
 ;;
 ;;  This compiler is adapted from Herbie

--- a/src/core2wls.rkt
+++ b/src/core2wls.rkt
@@ -7,8 +7,8 @@
 (define wls-supported (supported-list
   fpcore-ops
   fpcore-consts
-  '(binary64 real integer)
-  '(nearestEven)))
+  (curry set-member? '(binary64 real integer))
+  (curry set-member? 'nearestEven)))
 
 (define wls-reserved '(E Pi))  ; Language-specific reserved names (avoid name collisions)
 

--- a/src/fpcore-interpreter.rkt
+++ b/src/fpcore-interpreter.rkt
@@ -266,7 +266,9 @@
     [ceil (compute-with-bf bfceiling)] [floor (compute-with-bf bffloor)] 
     [trunc (λ (x) (if (< -1 x 0) -0.0 ((compute-with-bf bftruncate) x)))]
     [< <] [> >] [<= <=] [>= >=] [== my=] [!= my!=]
-    [and (λ (x y) (and x y))] [or (λ (x y) (or x y))] [not not]
+    [and (λ args (andmap identity args))] 
+    [or (λ args (ormap identity args))] 
+    [not not]
     [isnan nan?] [isinf infinite?]
     [nearbyint 
       (match (bf-rounding-mode)
@@ -347,7 +349,9 @@
     [/ (λ (x y) (bf->integer (parameterize ([bf-rounding-mode 'down]) (bf/ (bf x) (bf y)))))]
 
     [< <] [> >] [<= <=] [>= >=] [== my=] [!= my!=]
-    [and (λ (x y) (and x y))] [or (λ (x y) (or x y))] [not not]
+    [and (λ args (andmap identity args))] 
+    [or (λ args (ormap identity args))] 
+    [not not]
    )))
 
 ;;; binary80 evaluator 
@@ -400,7 +404,9 @@
     [>= (λ (x y . rest) (extfl-cmp extfl>= x y rest))]
     [== (λ (x y . rest) (extfl-cmp extfl= x y rest))]
     [!= (λ (x y . rest) (extfl-cmp (compose not extfl=) x y rest))]
-    [and (λ (x y) (and x y))] [or (λ (x y) (or x y))] [not not]
+    [and (λ args (andmap identity args))] 
+    [or (λ args (ormap identity args))] 
+    [not not]
     [isnan extfl-nan?] [isinf extfl-inf?]
     [cast identity]
 

--- a/src/fpcore-reader.rkt
+++ b/src/fpcore-reader.rkt
@@ -221,7 +221,7 @@
 ;;
 
 ; Adapted from Racket source:
-; github.com/racket/racket/blob/master/racket/src/cs/bootstrap.scheme-readtable.rkt
+; https://github.com/racket/racket/blob/master/racket/src/cs/bootstrap.scheme-readtable.rkt
 (define ((paren closer) c in src line col pos)
   (let loop ()
     (define c (peek-char in))
@@ -261,7 +261,5 @@
   (-> any/c input-port? (or/c fpcore? eof-object?))
   (parameterize ([read-decimal-as-inexact #f] 
                  [current-readtable fpcore-readtable])
-    ;(define p* (open-input-bytes (regexp-replace* #rx"#" (port->bytes p) "! :precision integer"))) ; expand '#' since this is special in Racket
-    ;(define stx (read-syntax name p*))
     (define stx (read-syntax name p))
     (if (eof-object? stx) stx (parse-fpcore stx))))

--- a/src/fpcore-visitor.rkt
+++ b/src/fpcore-visitor.rkt
@@ -68,8 +68,9 @@
      (vterm visitor ctx
             (visit-cast body)
             (visit-op_ 'cast (list body)))]
-    [(list (? operator? operator) args ...)
-     (vterm visitor ctx
+    ; TODO: digits probably doesn't go here
+    [(list (? (λ (x) (or (operator? x) (equal? x 'digits))) operator) args ...) 
+     (vterm visitor ctx 
             (visit-op operator args)
             (visit-op_ operator args))]
     [(or (? number? n) (? extflonum? n))

--- a/src/fpcore-visitor.rkt
+++ b/src/fpcore-visitor.rkt
@@ -2,7 +2,8 @@
 
 (require syntax/parse/define
          (for-syntax racket/syntax)
-         racket/hash)
+         racket/hash
+         racket/extflonum)
 
 (require "common.rkt")
 
@@ -71,7 +72,7 @@
      (vterm visitor ctx
             (visit-op operator args)
             (visit-op_ operator args))]
-    [(? number? n)
+    [(or (? number? n) (? extflonum? n))
      (vterm visitor ctx
             (visit-number n)
             (visit-terminal_ n))]

--- a/src/fpcore-visitor.rkt
+++ b/src/fpcore-visitor.rkt
@@ -21,14 +21,26 @@
    visit-while_
    visit-while
    visit-while*
+   visit-for_
+   visit-for
+   visit-for*
+   visit-tensor
+   visit-tensor*
+
    visit-!
-   visit-op_
-   visit-cast
-   visit-op
+
    visit-terminal_
    visit-number
    visit-constant
    visit-symbol
+   visit-digits
+
+   visit-op_
+   visit-cast
+   visit-array
+   visit-op
+   visit-call
+
    reduce))
 
 ;; Visit functions can take an optional context as a keyword argument.
@@ -77,16 +89,22 @@
      (vterm visitor ctx
             (visit-while* cond vars inits updates body)
             (visit-while_ 'while* cond vars inits updates body))]
+    [`(for ([,vars ,vals] ...) ([,accums ,inits ,updates] ...) ,body)
+     (vterm visitor ctx
+            (visit-for vars vals accums inits updates body)
+            (visit-for_ 'for vars vals accums inits updates body))]
+    [`(for* ([,vars ,vals] ...) ([,accums ,inits ,updates] ...) ,body)
+     (vterm visitor ctx
+            (visit-for* vars vals accums inits updates body)
+            (visit-for_ 'for* vars vals accums inits updates body))]
+    [`(tensor ([,vars ,vals] ...) ,body)
+     (vterm visitor ctx (visit-tensor vars vals body))]
+    [`(tensor* ([,vars ,vals] ...) ([,accums ,inits ,updates] ...) ,body)
+     (vterm visitor ctx (visit-tensor* vars vals accums inits updates body))]
+
     [`(! ,props ... ,body)
      (vterm visitor ctx (visit-! props body))]
-    [`(cast ,body)
-     (vterm visitor ctx
-            (visit-cast body)
-            (visit-op_ 'cast (list body)))]
-    [(list operator args ...)
-     (vterm visitor ctx
-            (visit-op operator args)
-            (visit-op_ operator args))]
+
     [(or (? number? n) (? extflonum? n))
      (vterm visitor ctx
             (visit-number n)
@@ -98,7 +116,28 @@
     [(? symbol? s)
      (vterm visitor ctx
             (visit-symbol s)
-            (visit-terminal_ s))]))
+            (visit-terminal_ s))]
+    [`(digits ,m ,e ,b)
+     (vterm visitor ctx
+            (visit-digits m e b)
+            (visit-terminal_ expr))]
+
+    [`(cast ,body)
+     (vterm visitor ctx
+            (visit-cast body)
+            (visit-op_ 'cast (list body)))]
+    [`(array ,args ...)
+     (vterm visitor ctx
+            (visit-array args)
+            (visit-op_ 'array args))]
+    [(list (? operator? operator) args ...)
+     (vterm visitor ctx
+            (visit-op operator args)
+            (visit-op_ operator args))]
+    [(list func args ...)
+     (vterm visitor ctx
+            (visit-call func args)
+            (visit-op_ func args))]))
 
 (define-syntax-rule (visit vtor arg)
   ((visitor-visit-expr vtor) vtor arg))
@@ -153,20 +192,45 @@
   (visit/ctx visitor body ctx)
   (void))
 
+(define (visit-for_ visitor for_ vars vals accums inits updates body #:ctx [ctx '()])
+  (for ([val vals]) (visit/ctx visitor val ctx))
+  (for ([init inits] [update updates])
+    (visit/ctx visitor init ctx)
+    (visit/ctx visitor update ctx))
+  (visit/ctx visitor body ctx)
+  (void))
+
+(define (visit-for visitor vars vals accums inits updates body #:ctx [ctx '()])
+  (for ([val vals]) (visit/ctx visitor val ctx))
+  (for ([init inits] [update updates])
+    (visit/ctx visitor init ctx)
+    (visit/ctx visitor update ctx))
+  (visit/ctx visitor body ctx)
+  (void))
+
+(define (visit-for* visitor vars vals accums inits updates body #:ctx [ctx '()])
+  (for ([val vals]) (visit/ctx visitor val ctx))
+  (for ([init inits] [update updates])
+    (visit/ctx visitor init ctx)
+    (visit/ctx visitor update ctx))
+  (visit/ctx visitor body ctx)
+  (void))
+
+(define (visit-tensor visitor vars vals body #:ctx [ctx '()])
+  (for ([val vals]) (visit/ctx visitor val ctx))
+  (visit/ctx visitor body ctx)
+  (void))
+
+(define (visit-tensor* visitor vars vals accums inits updates body #:ctx [ctx '()])
+  (for ([val vals]) (visit/ctx visitor val ctx))
+  (for ([init inits] [update updates])
+    (visit/ctx visitor init ctx)
+    (visit/ctx visitor update ctx))
+  (visit/ctx visitor body ctx)
+  (void))
+
 (define (visit-! visitor props body #:ctx [ctx '()])
   (visit/ctx visitor body ctx)
-  (void))
-
-(define (visit-op_ visitor operator args #:ctx [ctx '()])
-  (for ([arg args]) (visit/ctx visitor arg ctx))
-  (void))
-
-(define (visit-cast visitor body #:ctx [ctx '()])
-  (visit/ctx visitor body ctx)
-  (void))
-
-(define (visit-op visitor operator args #:ctx [ctx '()])
-  (for ([arg args]) (visit/ctx visitor arg ctx))
   (void))
 
 (define (visit-terminal_ visitor x #:ctx [ctx '()])
@@ -181,6 +245,29 @@
 (define (visit-symbol visitor x #:ctx [ctx '()])
   (void))
 
+(define (visit-digits visitor m e b #:ctx [ctx '()])
+  (void))
+
+(define (visit-op_ visitor operator args #:ctx [ctx '()])
+  (for ([arg args]) (visit/ctx visitor arg ctx))
+  (void))
+
+(define (visit-cast visitor body #:ctx [ctx '()])
+  (visit/ctx visitor body ctx)
+  (void))
+
+(define (visit-array visitor args #:ctx [ctx '()])
+  (for ([arg args]) (visit/ctx visitor arg ctx))
+  (void))
+
+(define (visit-op visitor operator args #:ctx [ctx '()])
+  (for ([arg args]) (visit/ctx visitor arg ctx))
+  (void))
+
+(define (visit-call visitor func args #:ctx [ctx '()])
+  (for ([arg args]) (visit/ctx visitor arg ctx))
+  (void))
+
 ;; visits the AST but does nothing
 (define default-visitor
   (visitor
@@ -192,14 +279,26 @@
    visit-while_
    #f
    #f
+   visit-for_
+   #f
+   #f
+   visit-tensor
+   visit-tensor*
+
    visit-!
-   visit-op_
-   #f
-   #f
+
    visit-terminal_
    #f
    #f
    #f
+   #f
+
+   visit-op_
+   #f
+   #f
+   #f
+   #f
+
    #f))
 
 ;; AST transformers
@@ -245,17 +344,44 @@
                 (visit/ctx visitor update ctx))))
      ,(visit/ctx visitor body ctx)))
 
+(define (visit-for_/transform visitor for_ vars vals accums inits updates body #:ctx [ctx '()])
+  `(,for_ (,@(for/list ([var vars] [val vals]) (list var (visit/ctx visitor val ctx))))
+          (,@(for/list ([accum accums] [init inits] [update updates])
+               (list accum
+                     (visit/ctx visitor init ctx)
+                     (visit/ctx visitor update ctx))))
+          ,(visit/ctx visitor body ctx)))
+
+(define (visit-for/transform visitor vars vals accums inits updates body #:ctx [ctx '()])
+  `(for (,@(for/list ([var vars] [val vals]) (list var (visit/ctx visitor val ctx))))
+     (,@(for/list ([accum accums] [init inits] [update updates])
+          (list accum
+                (visit/ctx visitor init ctx)
+                (visit/ctx visitor update ctx))))
+     ,(visit/ctx visitor body ctx)))
+
+(define (visit-for*/transform visitor vars vals accums inits updates body #:ctx [ctx '()])
+  `(for* (,@(for/list ([var vars] [val vals]) (list var (visit/ctx visitor val ctx))))
+     (,@(for/list ([accum accums] [init inits] [update updates])
+          (list accum
+                (visit/ctx visitor init ctx)
+                (visit/ctx visitor update ctx))))
+     ,(visit/ctx visitor body ctx)))
+
+(define (visit-tensor/transform visitor vars vals body #:ctx [ctx '()])
+  `(tensor (,@(for/list ([var vars] [val vals]) (list var (visit/ctx visitor val ctx))))
+           ,(visit/ctx visitor body ctx)))
+
+(define (visit-tensor*/transform visitor vars vals accums inits updates body #:ctx [ctx '()])
+  `(tensor* (,@(for/list ([var vars] [val vals]) (list var (visit/ctx visitor val ctx))))
+            (,@(for/list ([accum accums] [init inits] [update updates])
+                 (list accum
+                       (visit/ctx visitor init ctx)
+                       (visit/ctx visitor update ctx))))
+            ,(visit/ctx visitor body ctx)))
+
 (define (visit-!/transform visitor props body #:ctx [ctx '()])
   `(! ,@props ,(visit/ctx visitor body ctx)))
-
-(define (visit-op_/transform visitor operator args #:ctx [ctx '()])
-  `(,operator ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
-
-(define (visit-cast/transform visitor body #:ctx [ctx '()])
-  `(cast ,(visit/ctx visitor body ctx)))
-
-(define (visit-op/transform visitor operator args #:ctx [ctx '()])
-  `(,operator ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
 
 (define (visit-terminal_/transform visitor x #:ctx [ctx '()])
   x)
@@ -269,6 +395,24 @@
 (define (visit-symbol/transform visitor x #:ctx [ctx '()])
   x)
 
+(define (visit-digits/transform visitor m e b #:ctx [ctx '()])
+  `(digits ,m ,e ,b))
+
+(define (visit-op_/transform visitor operator args #:ctx [ctx '()])
+  `(,operator ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-cast/transform visitor body #:ctx [ctx '()])
+  `(cast ,(visit/ctx visitor body ctx)))
+
+(define (visit-array/transform visitor args #:ctx [ctx '()])
+  `(array ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-op/transform visitor operator args #:ctx [ctx '()])
+  `(,operator ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-call/transform visitor func args #:ctx [ctx '()])
+  `(,func ,@(for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
 ;; returns the AST unchanged
 (define default-transform-visitor
   (visitor
@@ -280,14 +424,26 @@
    visit-while_/transform
    #f
    #f
+   visit-for_/transform
+   #f
+   #f
+   visit-tensor/transform
+   visit-tensor*/transform
+
    visit-!/transform
-   visit-op_/transform
-   #f
-   #f
+
    visit-terminal_/transform
    #f
    #f
    #f
+   #f
+
+   visit-op_/transform
+   #f
+   #f
+   #f
+   #f
+
    #f))
 
 ;; AST reductions
@@ -337,19 +493,45 @@
                                         (visit/ctx visitor update ctx))))
                   (list (visit/ctx visitor body ctx)))))
 
+(define (visit-for_/reduce visitor for_ vars vals accums inits updates body #:ctx [ctx '()])
+  (reduce visitor
+          (append (for/list ([val vals]) (visit/ctx visitor val ctx))
+                  (apply append (for/list ([init inits] [update updates])
+                                  (list (visit/ctx visitor init ctx)
+                                        (visit/ctx visitor update ctx))))
+                  (list (visit/ctx visitor body ctx)))))
+
+(define (visit-for/reduce visitor vars vals accums inits updates body #:ctx [ctx '()])
+  (reduce visitor
+          (append (for/list ([val vals]) (visit/ctx visitor val ctx))
+                  (apply append (for/list ([init inits] [update updates])
+                                  (list (visit/ctx visitor init ctx)
+                                        (visit/ctx visitor update ctx))))
+                  (list (visit/ctx visitor body ctx)))))
+
+(define (visit-for*/reduce visitor vars vals accums inits updates body #:ctx [ctx '()])
+  (reduce visitor
+          (append (for/list ([val vals]) (visit/ctx visitor val ctx))
+                  (apply append (for/list ([init inits] [update updates])
+                                  (list (visit/ctx visitor init ctx)
+                                        (visit/ctx visitor update ctx))))
+                  (list (visit/ctx visitor body ctx)))))
+
+(define (visit-tensor/reduce visitor vars vals body #:ctx [ctx '()])
+  (reduce visitor
+          (append (for/list ([val vals]) (visit/ctx visitor val ctx))
+                  (list (visit/ctx visitor body ctx)))))
+
+(define (visit-tensor*/reduce visitor vars vals accums inits updates body #:ctx [ctx '()])
+  (reduce visitor
+          (append (for/list ([val vals]) (visit/ctx visitor val ctx))
+                  (apply append (for/list ([init inits] [update updates])
+                                  (list (visit/ctx visitor init ctx)
+                                        (visit/ctx visitor update ctx))))
+                  (list (visit/ctx visitor body ctx)))))
+
 (define (visit-!/reduce visitor props body #:ctx [ctx '()])
   (reduce visitor (list (visit/ctx visitor body ctx))))
-
-(define (visit-op_/reduce visitor operator args #:ctx [ctx '()])
-  (reduce visitor
-          (for/list ([arg args]) (visit/ctx visitor arg ctx))))
-
-(define (visit-cast/reduce visitor body #:ctx [ctx '()])
-  (reduce visitor (list (visit/ctx visitor body ctx))))
-
-(define (visit-op/reduce visitor operator args #:ctx [ctx '()])
-  (reduce visitor
-          (for/list ([arg args]) (visit/ctx visitor arg ctx))))
 
 (define (visit-terminal_/reduce visitor x #:ctx [ctx '()])
   1)
@@ -363,6 +545,28 @@
 (define (visit-symbol/reduce visitor x #:ctx [ctx '()])
   1)
 
+(define (visit-digits/reduce visitor m e b #:ctx [ctx '()])
+  1)
+
+(define (visit-op_/reduce visitor operator args #:ctx [ctx '()])
+  (reduce visitor
+          (for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-cast/reduce visitor body #:ctx [ctx '()])
+  (reduce visitor (list (visit/ctx visitor body ctx))))
+
+(define (visit-array/reduce visitor args #:ctx [ctx '()])
+  (reduce visitor
+          (for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-op/reduce visitor operator args #:ctx [ctx '()])
+  (reduce visitor
+          (for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
+(define (visit-call/reduce visitor func args #:ctx [ctx '()])
+  (reduce visitor
+          (for/list ([arg args]) (visit/ctx visitor arg ctx))))
+
 ;; counts terminals
 (define default-reduce-visitor
   (visitor
@@ -374,14 +578,26 @@
    visit-while_/reduce
    #f
    #f
+   visit-for_/reduce
+   #f
+   #f
+   visit-tensor/reduce
+   visit-tensor*/reduce
+
    visit-!/reduce
-   visit-op_/reduce
-   #f
-   #f
+
    visit-terminal_/reduce
    #f
    #f
    #f
+   #f
+
+   visit-op_/reduce
+   #f
+   #f
+   #f
+   #f
+
    (curry apply +)))
 
 ;; syntax helpers

--- a/src/fpcore-visitor.rkt
+++ b/src/fpcore-visitor.rkt
@@ -68,8 +68,7 @@
      (vterm visitor ctx
             (visit-cast body)
             (visit-op_ 'cast (list body)))]
-    ; TODO: digits probably doesn't go here
-    [(list (? (λ (x) (or (operator? x) (equal? x 'digits))) operator) args ...) 
+    [(list operator args ...) 
      (vterm visitor ctx 
             (visit-op operator args)
             (visit-op_ operator args))]

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -65,7 +65,7 @@
 
 (define (convert-application ctx operator args)
   (match (cons operator args)
-    [(list '- a) (round-expr (format (if (string-prefix? a "-") "-(~a)" "~a") a) ctx)]
+    [(list '- a) (round-expr (format (if (string-prefix? a "-") "-(~a)" "-~a") a) ctx)]
     [(list 'not a) (format "!~a" a)]
     [(list (or '== '!= '< '> '<= '>=)) "TRUE"]
     [(list (or '+ '- '*) a b) (round-expr (format "(~a ~a ~a)" a operator b) ctx)]  ; Division not included!! (Sollya issues)

--- a/src/supported.rkt
+++ b/src/supported.rkt
@@ -45,18 +45,23 @@
 
 (define (valid-core core supp)
   (define core-prec (dict-ref (property-values core) ':precision #f))
+  (define core-rnd-modes (dict-ref (property-values core) ':precision #f))
   (and (andmap (supported-list-ops supp) (operators-in core))
        (andmap (supported-list-consts supp) (constants-in core))
-       (andmap (supported-list-round-modes supp) (round-modes-in core))
+       (or (not core-rnd-modes)
+           (andmap (supported-list-round-modes supp) (set->list core-rnd-modes)))
        (or (not core-prec)
            (andmap (supported-list-precisions supp) (set->list core-prec)))))
 
 (define (unsupported-features core supp)
   (define core-prec (dict-ref (property-values core) ':precision #f))
+  (define core-rnd-modes (dict-ref (property-values core) ':precision #f))
   (set-union
     (filter-not (supported-list-ops supp) (operators-in core))
     (filter-not (supported-list-consts supp) (constants-in core))
-    (filter-not (supported-list-round-modes supp) (round-modes-in core))
+    (if core-rnd-modes
+        (filter-not (supported-list-round-modes supp) (set->list core-rnd-modes))
+        '())
     (if core-prec
         (filter-not (supported-list-precisions supp) (set->list core-prec))
         '())))

--- a/src/supported.rkt
+++ b/src/supported.rkt
@@ -1,9 +1,9 @@
 #lang racket
-(require "common.rkt" "fpcore-checker.rkt")
+(require "common.rkt" "fpcore-checker.rkt" "fpcore-visitor.rkt")
 (provide valid-core unsupported-features 
          invert-op-proc invert-const-proc invert-rnd-mode-proc
          ieee754-ops ieee754-rounding-modes fpcore-ops fpcore-consts
-         operators-in constants-in property-values round-modes-in variables-in-expr)
+         operators-in constants-in property-values variables-in-expr)
 
 (provide
   (contract-out
@@ -12,6 +12,9 @@
       [consts (-> symbol? boolean?)]
       [precisions (-> symbol? boolean?)]
       [round-modes (-> symbol? boolean?)])]))
+
+(module+ test
+  (require rackunit))
 
 ;;; Predefined supported procs
 
@@ -60,61 +63,29 @@
 
 (define/contract (operators-in-expr expr)
   (-> expr? (listof symbol?))
-  (remove-duplicates
-   (match expr
-     [`(while ,test ([,vars ,inits ,updates] ...) ,res)
-      (cons 'while
-            (append (operators-in-expr test)
-                    (append-map operators-in-expr inits)
-                    (append-map operators-in-expr updates)
-                    (operators-in-expr res)))]
-     [`(while* ,test ([,vars ,inits ,updates] ...) ,res)
-      (cons 'while*
-            (append (operators-in-expr test)
-                    (append-map operators-in-expr inits)
-                    (append-map operators-in-expr updates)
-                    (operators-in-expr res)))]
-     [`(let ([,vars ,vals] ...) ,body)
-      (cons 'let (append (append-map operators-in-expr vals) (operators-in-expr body)))]
-     [`(let* ([,vars ,vals] ...) ,body)
-      (cons 'let* (append (append-map operators-in-expr vals) (operators-in-expr body)))]
-     [`(if ,cond ,ift ,iff)
-      (cons 'if (append (operators-in-expr cond) (operators-in-expr ift) (operators-in-expr iff)))]
-     [`(! ,props ... ,body)
-      (cons '! (operators-in-expr body))]
-     [(list op args ...) (cons op (append-map operators-in-expr args))]
-     [(? hex?) '()]
-     [(? symbol?) '()]
-     [(? number?) '()])))
+  (define vtor
+    (struct-copy visitor default-reduce-visitor ; default behavior is counting terminals
+      [visit-terminal_ (λ (vtor a #:ctx ctx) '())]
+      [visit-op (λ (vtor op args #:ctx ctx) (list op))]
+      [reduce (curry apply append)]))
+  (remove-duplicates (visit vtor expr)))
 
 (define/contract (operators-in core)
   (-> fpcore? (listof symbol?))
   (define-values (args props body)
     (match core
      [(list 'FPCore (list args ...) props ... body) (values args props body)]
-    [(list 'FPCore name (list args ...) props ... body) (values args props body)]))
+     [(list 'FPCore name (list args ...) props ... body) (values args props body)]))
   (operators-in-expr body))
 
 (define/contract (constants-in-expr expr)
   (-> expr? (listof symbol?))
-  (remove-duplicates
-   (match expr
-     [`(,(or 'while 'while*) ,test ([,vars ,inits ,updates] ...) ,res)
-            (append (constants-in-expr test)
-                    (append-map constants-in-expr inits)
-                    (append-map constants-in-expr updates)
-                    (constants-in-expr res))]
-     [`(,(or 'let 'let*) ([,vars ,vals] ...) ,body)
-      (append (append-map constants-in-expr vals) (constants-in-expr body))]
-     [`(if ,cond ,ift ,iff)
-      (append (constants-in-expr cond) (constants-in-expr ift) (constants-in-expr iff))]
-     [`(! ,props ... ,body)
-      (constants-in-expr body)]
-     [(list op args ...) (append-map constants-in-expr args)]
-     [(? constant?) (list expr)]
-     [(? hex?) '()]
-     [(? symbol?) '()]
-     [(? number?) '()])))
+  (define vtor
+    (struct-copy visitor default-reduce-visitor ; default behavior is counting terminals
+      [visit-terminal_ (λ (vtor a #:ctx ctx) '())]
+      [visit-constant (λ (vtor a #:ctx ctx) (list a))]
+      [reduce (curry apply append)]))
+  (remove-duplicates (visit vtor expr)))
 
 (define/contract (constants-in core)
   (-> fpcore? (listof symbol?))
@@ -133,21 +104,12 @@
 (define/contract (property-values-expr expr)
   (-> expr? property-hash?)
   (define out (make-hash))
-  (let loop ([expr expr])
-    (match expr
-      [`(,(or 'while 'while*) ,test ([,vars ,inits ,updates] ...) ,res)
-       (loop test) (for-each loop inits) (for-each loop updates) (loop res)]
-      [`(,(or 'let 'let*) ([,vars ,vals] ...) ,body)
-       (for-each loop vals) (loop body)]
-      [`(if ,cond ,ift ,iff)
-       (loop cond) (loop ift) (loop iff)]
-      [`(! ,props ... ,body)
-       (property-hash-add! out props)
-       (loop body)]
-      [(list op args ...) (for-each loop args)]
-      [(? hex?) (void)]
-      [(? symbol?) (void)]
-      [(? number?) (void)]))
+  (define vtor
+    (struct-copy visitor default-transform-visitor
+      [visit-! (λ (vtor props body #:ctx ctx)
+                  (property-hash-add! out props)
+                  (visit-!/transform vtor props body #:ctx ctx))]))
+  (visit vtor expr)
   out)
 
 (define/contract (property-values core)
@@ -158,61 +120,36 @@
      [(list 'FPCore name (list args ...) props ... body) (values args props body)]))
   (define prop-hash (property-values-expr body))
   (property-hash-add! prop-hash props)
-  prop-hash)
-
-(define/contract (round-modes-in-expr expr)
-  (-> expr? (listof symbol?))
-  (remove-duplicates
-   (match expr
-     [`(,(or 'while 'while*) ,test ([,vars ,inits ,updates] ...) ,res)
-            (append (round-modes-in-expr test)
-                    (append-map round-modes-in-expr inits)
-                    (append-map round-modes-in-expr updates)
-                    (round-modes-in-expr res))]
-     [`(,(or 'let 'let*) ([,vars ,vals] ...) ,body)
-      (append (append-map round-modes-in-expr vals) (round-modes-in-expr body))]
-     [`(if ,cond ,ift ,iff)
-      (append (round-modes-in-expr cond) (round-modes-in-expr ift) (round-modes-in-expr iff))]
-     [`(! ,props ... ,body)
-      (let ([rnd-mode (dict-ref (apply hash-set* #hash() props) ':round #f)])
-        (append (round-modes-in-expr body)
-                (if (equal? rnd-mode #f) '() (list rnd-mode))))]
-     [(list op args ...) (append-map round-modes-in-expr args)]
-     [(? constant?) '()]
-     [(? hex?) '()]
-     [(? symbol?) '()]
-     [(? number?) '()])))
-
-(define/contract (round-modes-in core)
-  (-> fpcore? (listof symbol?))
-  (define-values (args props body)
-    (match core
-     [(list 'FPCore (list args ...) props ... body) (values args props body)]
-     [(list 'FPCore name (list args ...) props ... body) (values args props body)]))
-  (remove-duplicates
-    (let ([rnd-mode (dict-ref (apply hash-set* #hash() props) ':round #f)]
-          [in-body (round-modes-in-expr body)])
-        (if (equal? rnd-mode #f) 
-            (append in-body '(nearestEven)) 
-            (append (list rnd-mode) in-body))))) 
+  prop-hash) 
 
 (define/contract (variables-in-expr expr)
   (-> expr? (listof symbol?))
-  (remove-duplicates
-   (match expr
-     [`(,(or 'while 'while*) ,test ([,vars ,inits ,updates] ...) ,res)
-            (append (variables-in-expr test)
-                    (append-map variables-in-expr inits)
-                    (append-map variables-in-expr updates)
-                    (variables-in-expr res))]
-     [`(,(or 'let 'let*) ([,vars ,vals] ...) ,body)
-      (append (append-map variables-in-expr vals) (variables-in-expr body))]
-     [`(if ,cond ,ift ,iff)
-      (append (variables-in-expr cond) (variables-in-expr ift) (variables-in-expr iff))]
-     [`(! ,props ... ,body)
-      (variables-in-expr body)]
-     [(list op args ...) (append-map variables-in-expr args)]
-     [(? constant?) '()]
-     [(? hex?) '()]
-     [(? symbol?) '(list expr)]
-     [(? number?) '()])))
+  (define vtor
+    (struct-copy visitor default-reduce-visitor ; default behavior is counting terminals
+      [visit-terminal_ (λ (vtor a #:ctx ctx) '())]
+      [visit-symbol (λ (vtor a #:ctx ctx) (list a))]
+      [reduce (curry apply append)]))
+  (remove-duplicates (visit vtor expr)))
+
+(module+ test
+  (define exprs (list
+    `(+ a b)
+    `(* (+ a b) E)
+    `(let ([a LOG2E] [b 2]) (sqrt (/ a b)))
+    `(let* ([a 1] [b PI]) (cbrt (/ a b)))
+    `(while (< a b) ([a 0 (+ a 2)] [b 100 (- b 1)]) (* (exp a) (sin b)))
+    `(while* (< a b) ([a 0 (+ a 2)] [b 100 (- b 1)]) (* (log a) (cos b)))
+    `(! :precision binary64 (- (! :round toPositive (+ x y)) (! :round toNegative (+ x y))))))
+
+  (check-equal?
+    (map operators-in-expr exprs)
+   `((+) (*) (sqrt) (cbrt) (< + - *) (< + - *) (-)))
+
+  (check-equal?
+    (map constants-in-expr exprs)
+   `(() (E) (LOG2E) (PI) () () ()))
+
+  (check-equal?
+    (map property-values-expr exprs)
+    (list (make-hash) (make-hash) (make-hash) (make-hash) (make-hash) (make-hash) 
+        (make-hash `((:precision . ,(set 'binary64)) (:round . ,(set 'toNegative 'toPositive)))))))

--- a/tests/sanity/constants.fpcore
+++ b/tests/sanity/constants.fpcore
@@ -1,90 +1,57 @@
 (FPCore () :name "Test E (1/1)" :spec 1.0 (if (and (< 2.0 E) (< E 3.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test LOG2E (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test LOG2E (1/1)"
+ :spec 1.0
  (if (and (< 1.0 LOG2E) (< LOG2E 2.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test LOG10E (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test LOG10E (1/1)"
+ :spec 1.0
  (if (and (< 0.25 LOG10E) (< LOG10E 0.5)) 1 0))
 
-(FPCore
- ()
- :name
- "Test LN2 (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test LN2 (1/1)"
+ :spec 1.0
  (if (and (< 0.5 LN2) (< LN2 1.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test PI (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test PI (1/1)"
+ :spec 1.0
  (if (and (< 3.0 PI) (< PI 4.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test PI_2 (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test PI_2 (1/1)"
+ :spec 1.0
  (if (and (< 1.0 PI_2) (< PI_2 2.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test PI_4 (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test PI_4 (1/1)"
+ :spec 1.0
  (if (and (< 0.5 PI_4) (< PI_4 1.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test M_1_PI (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test M_1_PI (1/1)"
+ :spec 1.0
  (if (and (< 0.25 M_1_PI) (< M_1_PI 0.5)) 1 0))
 
-(FPCore
- ()
- :name
- "Test M_2_PI (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test M_2_PI (1/1)"
+ :spec 1.0
  (if (and (< 0.5 M_2_PI) (< M_2_PI 1.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test M_2_SQRTPI (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test M_2_SQRTPI (1/1)"
+ :spec 1.0
  (if (and (< 1.0 M_2_SQRTPI) (< M_2_SQRTPI 2.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test SQRT2 (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test SQRT2 (1/1)"
+ :spec 1.0
  (if (and (< 1.0 SQRT2) (< SQRT2 2.0)) 1 0))
 
-(FPCore
- ()
- :name
- "Test SQRT1_2 (1/1)"
- :spec
- 1.0
+(FPCore ()
+ :name "Test SQRT1_2 (1/1)"
+ :spec 1.0
  (if (and (< 0.5 SQRT1_2) (< SQRT1_2 1.0)) 1 0))
 

--- a/tests/scripts/test-export.out.txt
+++ b/tests/scripts/test-export.out.txt
@@ -119,22 +119,12 @@ Expressions
 	let rnd64= (arg01 - arg11);
 }
 
-set-member?: contract violation:
-expected: set?
-given: 'nearestEven
-argument position: 1st
-other arguments...:
-  x: 'nearestEven
-  context...:
-   /home/bsaiki/Programs/racket/racket/collects/racket/private/generic.rkt:475:9: set-member?
-   /home/bsaiki/Programs/racket/racket/collects/racket/list.rkt:592:0: filter-not
-   /home/bsaiki/Documents/FPBench/repo/src/supported.rkt:51:0: unsupported-features
-   /home/bsaiki/Documents/FPBench/repo/export.rkt:88:3: for-loop
-   ...cket/cmdline.rkt:191:51
-   (submod "/home/bsaiki/Documents/FPBench/repo/export.rkt" main): [running body]
-   temp35_0
-   for-loop
-   run-module-instance!
+ex0[arg0_, arg1_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, (arg0 + arg1)]
+
+ex1[arg0_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, Sqrt[arg0]]
+
+ex2[arg0_, arg1_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, With[{arg0$1 = arg1, arg1$2 = arg0}, (arg0$1 - arg1$2)]]
+
 procedure copysign(x, y) { var res; if (y < 0) then res = -abs(x) else res = abs(x); return res; };
 procedure fdim(x, y) { var res; if (x != x || y != y) then res = nan else if (x > y) then res = x - y else res = 0; return res; };
 procedure isfinite(x) { return (x == x && abs(x) != infty); };

--- a/tests/scripts/test-export.out.txt
+++ b/tests/scripts/test-export.out.txt
@@ -1,15 +1,15 @@
 double ex0(double arg0, double arg1) {
-	return ((double) (arg0 + arg1));
+	return arg0 + arg1;
 }
 
 double ex1(double arg0) {
-	return ((double) sqrt(arg0));
+	return sqrt(arg0);
 }
 
 double ex2(double arg0, double arg1) {
 	double arg0_1 = arg1;
 	double arg1_2 = arg0;
-	return ((double) (arg0_1 - arg1_2));
+	return arg0_1 - arg1_2;
 }
 
 package main
@@ -43,7 +43,7 @@ function pow(x, y) { if (x == 1.0 && isNaN(y)) { return 1.0; } else { return Cus
 function fdim(x , y) { if (x != x || y != y) { return NaN; } else if (x > y) { return x - y; } else { return 0; }}
 
 function ex0(arg0, arg1) {
-	return (arg0 + arg1);
+	return arg0 + arg1;
 }
 
 function ex1(arg0) {
@@ -53,7 +53,7 @@ function ex1(arg0) {
 function ex2(arg0, arg1) {
 	var arg0_1 = arg1;
 	var arg1_2 = arg0;
-	return (arg0_1 - arg1_2);
+	return arg0_1 - arg1_2;
 }
 
 arg0 = float<ieee_64,ne>(Marg0);
@@ -119,12 +119,22 @@ Expressions
 	let rnd64= (arg01 - arg11);
 }
 
-ex0[arg0_, arg1_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, (arg0 + arg1)]
-
-ex1[arg0_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, Sqrt[arg0]]
-
-ex2[arg0_, arg1_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, With[{arg0$1 = arg1, arg1$2 = arg0}, (arg0$1 - arg1$2)]]
-
+set-member?: contract violation:
+expected: set?
+given: 'nearestEven
+argument position: 1st
+other arguments...:
+  x: 'nearestEven
+  context...:
+   /home/bsaiki/Programs/racket/racket/collects/racket/private/generic.rkt:475:9: set-member?
+   /home/bsaiki/Programs/racket/racket/collects/racket/list.rkt:592:0: filter-not
+   /home/bsaiki/Documents/FPBench/repo/src/supported.rkt:51:0: unsupported-features
+   /home/bsaiki/Documents/FPBench/repo/export.rkt:88:3: for-loop
+   ...cket/cmdline.rkt:191:51
+   (submod "/home/bsaiki/Documents/FPBench/repo/export.rkt" main): [running body]
+   temp35_0
+   for-loop
+   run-module-instance!
 procedure copysign(x, y) { var res; if (y < 0) then res = -abs(x) else res = abs(x); return res; };
 procedure fdim(x, y) { var res; if (x != x || y != y) then res = nan else if (x > y) then res = x - y else res = 0; return res; };
 procedure isfinite(x) { return (x == x && abs(x) != infty); };
@@ -137,7 +147,7 @@ procedure div_warn(x, y) { if (x != 0 && y == 0) then print("[WARNING] FPBench: 
 procedure ex0(arg0, arg1) {
 	arg0 = round(arg0, double, RN);
 	arg1 = round(arg1, double, RN);
-	round((arg0 + arg1), double, RN);
+	round(arg0 + arg1, double, RN);
 };
 
 procedure ex1(arg0) {
@@ -151,7 +161,7 @@ procedure ex2(arg0, arg1) {
 	arg1 = round(arg1, double, RN);
 	arg0_1 = arg1;
 	arg1_2 = arg0;
-	round((arg0_1 - arg1_2), double, RN);
+	round(arg0_1 - arg1_2, double, RN);
 };
 
 fun ex0 (arg0 : word64) (arg1 : word64) = (Double.+ arg0 arg1) : word64;


### PR DESCRIPTION
This PR refactors compiler code, cleans up compiler output, and fixes test generation.
- [x] switches supported lists to procedures
- [x] cleanup compiler output: 
   -  removes redundant casts
   -  trims redundant parentheses in output
   -  nested `if` statements export with `if`, `else if`, `else` branches
- [x] fixes gen-expr.rkt
- [x] pretty formatter for FPCores and expressions
- [x] allows tex compiler to export any operator