### PR TITLE
A new FPTaylor compiler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: "C sanity"
         id: c_sanity
-      # if: ${{ steps.setup.outcome == 'success' }}
+        # if: ${{ steps.setup.outcome == 'success' }}
         run: make c-sanity
 
       - name: "JS sanity"
@@ -143,7 +143,7 @@ jobs:
       
       - name: "FPTaylor test"
         if: ${{ (success() || failure()) && steps.fptaylor_sanity.outcome == 'success' }} 
-        run: make fptaylor-test
+        run: eval `opam config env` && make fptaylor-test
 
       - name: "Daisy test"
         if: ${{ (success() || failure()) && steps.daisy_sanity.outcome == 'success' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: build
 on: [push]
 
 env:
-  FPTAYLOR_VERSION: 'a318f5b2c83a389777a7ef9a0c094f54412bcda2'
+  FPTAYLOR_VERSION: 'fabc895ddc595dc41fbe7ce511049c745e1f9136'
   FPLLL_VERSION: '5.2.1'
   SOLLYA_VERSION: 'sollya-7.0'
   CAKEML_VERSION: 'v1217'
@@ -39,14 +39,15 @@ jobs:
       - name: "Setup environment"
         run: |     
           sudo apt-get update
-          sudo apt-get install -y gnuplot libmpfr-dev libmpfi-dev libxml2-dev flex bison ocaml
+          sudo apt-get install -y gnuplot libmpfr-dev libmpfi-dev libxml2-dev flex bison opam
+          opam init && opam switch 4.04.2 && eval `opam config env`
           (git clone https://github.com/fplll/fplll.git ../cache/fplll || echo "Assuming FPLLL cached, skipping clone")
           (cd ../cache/fplll && git checkout ${FPLLL_VERSION} && ./autogen.sh && ./configure && make && sudo make install && sudo ldconfig)
           (git clone https://scm.gforge.inria.fr/anonscm/git/sollya/sollya.git ../cache/sollya || echo "Assuming sollya cached, skipping clone")
           (cd ../cache/sollya && git checkout ${SOLLYA_VERSION} && ./autogen.sh && ./configure && make && sudo make install && sudo ldconfig)   
           which sollya
           (git clone https://github.com/soarlab/FPTaylor.git ../cache/fptaylor || echo "Asuming FPTaylor cached, skipping clone")
-          (cd ../cache/fptaylor && git checkout ${FPTAYLOR_VERSION} && make)
+          (cd ../cache/fptaylor && git checkout ${FPTAYLOR_VERSION} && make clean-all && make)
           [[ ! -d "../cache/${Z3_DISTR}" ]] && curl -L -O https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/${Z3_DISTR}.zip && \
              unzip ${Z3_DISTR}.zip -d ../cache || echo "z3 cached"
           (mkdir ../cache/cake && curl -L https://github.com/CakeML/cakeml/releases/download/${CAKEML_VERSION}/cake-x64-64.tar.gz | \

--- a/export.rkt
+++ b/export.rkt
@@ -60,7 +60,6 @@
    
    (define-values (header export footer supported)
      (match extension
-       ["fptaylor" (values (const "") (curry core->fptaylor #:inexact-scale (*scale*)) (const "") fptaylor-supported)]
        [(or "gappa" "g") (values (const "") (curry core->gappa #:rel-error (*rel-error*)) (const "") gappa-supported)]
        [#f (raise-user-error "Please specify an output language (using the --lang flag)")]
        [_
@@ -76,6 +75,7 @@
 
    (when (and (equal? extension "js") (*runtime*)) (js-runtime (*runtime*)))
    (when (and (equal? extension "sollya") suppress-warnings) (*sollya-warnings* #f))
+   (when (and (set-member? '("fptaylor" "fpt") extension) (*scale*)) (*fptaylor-inexact-scale* (*scale*)))
    (when (equal? extension "scala") 
     (let ([out-name (if (equal? out-file "-") 
                         "stdout" 

--- a/infra/test-common.rkt
+++ b/infra/test-common.rkt
@@ -53,10 +53,10 @@
 
 ;;; Misc
 
-(define (run-with-time-limit exe args [time-limit (*tool-time-limit*)])
+(define (run-with-time-limit exe #:time-limit [time-limit (*tool-time-limit*)] . args)
   (define t0 (current-seconds))
   (define-values (p stdout stdin stderr)
-    (subprocess #f #f #f (find-executable-path exe) args))
+    (apply subprocess #f #f #f (find-executable-path exe) args))
   (close-output-port stdin)
   (let loop ()
     (cond

--- a/infra/test-core2fptaylor.rkt
+++ b/infra/test-core2fptaylor.rkt
@@ -16,7 +16,9 @@
   test-file)
 
 (define (run<-fptaylor exec-name ctx type number)
-  (define out (run-with-time-limit "fptaylor" exec-name))
+  (define out (run-with-time-limit "fptaylor" 
+                "--find-bounds=true" "--print-precision=20"
+                exec-name))
   (define timeout? #f)
   (define out*
     (cond 
@@ -29,7 +31,7 @@
                                           #rx"Bounds [(]without rounding[)]: [^\n]*"
                                           out))
         (define conservative_bounds (regexp-match*
-                                    #rx"([+-]?[0-9]+[.][0-9]+[eE][+-]?[0-9]+)|([-]?inf)|([-]?nan)"
+                                    #rx"([+-]?[0-9]+(?:[.][0-9]+(?:[eE][+-]?[0-9]+)?)?)|([-]?inf)|([-]?nan)"
                                     (car conservative_bounds_line)))
         (cons (car conservative_bounds) (cadr conservative_bounds))]
       [else
@@ -37,7 +39,7 @@
                             #rx"Bounds [(]floating-point[)]: [^\n]*"
                             out))
         (define bounds (regexp-match*
-                        #rx"[+-]?[0-9]+[.][0-9]+[eE][+-]?[0-9]+"
+                        #rx"[+-]?[0-9]+(?:[.][0-9]+(?:[eE][+-]?[0-9]+)?)?"
                         (car bounds_line)))
         (cons (car bounds) (cadr bounds))]))
   (if timeout?

--- a/src/core2fptaylor.rkt
+++ b/src/core2fptaylor.rkt
@@ -96,7 +96,7 @@
     ['SQRT2 "sqrt(2)"]
     ['SQRT1_2 "1 / sqrt(2)"]
     [(? hex? expr) (format "~a" expr)]
-    [(? number? expr) (format "~a" expr)]
+    [(? number? expr) (format-number expr)]
     [c (error 'constant->expr "Unsupported constant ~a" c)]))
 
 (define (constant->fptaylor props expr)
@@ -110,8 +110,11 @@
   (format "~a = ~a;" var val))
 
 (define (function->fptaylor name args arg-props body return ctx vars)
+  (define expr-name
+    (let ([name* (ctx-lookup-prop ctx ':name #f)])
+      (if name* (let-values ([(_ name) (ctx-unique-name ctx name*)]) name) name)))
   (define pre ((compose canonicalize remove-let)
-                  (dict-ref (ctx-props ctx) ':pre 'TRUE)))
+                (dict-ref (ctx-props ctx) ':pre 'TRUE)))
   (define var-ranges 
     (make-immutable-hash 
       (dict-map (condition->range-table pre) 
@@ -143,7 +146,7 @@
     ; TODO: constraints
 
     (format "{\n~a~aExpressions\n\t~a = ~a;\n}"
-      var-string def-string name return))
+      var-string def-string expr-name return))
 
 (define fptaylor-language 
   (language "fptaylor" 

--- a/src/core2fptaylor.rkt
+++ b/src/core2fptaylor.rkt
@@ -35,7 +35,7 @@
                 sinh cosh tanh asinh acosh atanh) op))
 
 (define/match (prec->fptaylor prec)
-  [(#f) ""]
+  [('undefined) ""]
   [('real) "real"]
   [('binary16) "float16"]
   [('binary32) "float32"]
@@ -57,7 +57,7 @@
   (define rm (rm->fptaylor (dict-ref props ':round 'nearestEven)))
   (define bits
     (match prec
-      [#f "undefined"]
+      ['undefined "undefined"]
       ['real ""]
       ['binary16 "16"]
       ['binary32 "32"]
@@ -65,7 +65,7 @@
       ['binary128 "128"]
       [_ (error 'round->fptaylor "Unsupported precision ~a" prec)]))
   (cond
-    [(equal? bits "undefined") format "rnd(~a)" (trim-infix-parens expr)]
+    [(equal? bits "undefined") (format "rnd(~a)" (trim-infix-parens expr))]
     [(equal? bits "") expr]
     [(and (equal? rm "ne") (= scale 1)) (format "rnd~a(~a)" bits (trim-infix-parens expr))]
     [else (format "rnd[~a,~a,~a](~a)" bits rm scale (trim-infix-parens expr))]))
@@ -220,16 +220,15 @@
         ;;; (with-handlers ([exn:fail? (λ (exn) (eprintf "[ERROR]: ~a\n\n" exn))])
           (define def-name (format "ex~a" n))
           (define prog-name (if (auto-file-names) def-name (fpcore-name prog def-name)))
+          (define override-props (if (precision) `(:precision ,(precision)) null))
           (define progs (fpcore-transform prog
+                                          #:var-precision (var-precision)
+                                          #:override-props override-props
                                           #:unroll (unroll)
                                           #:split (split)
                                           #:subexprs (subexprs)
                                           #:split-or (split-or)))
           (define results (map (curryr core->fptaylor def-name) progs))
-                              ;;;         #:precision (precision)
-                              ;;;         #:var-precision (var-precision)
-                              ;;;         #:indent "  ")
-                              ;;;  progs))
           (define multiple-results (> (length results) 1))
           (cond
             [(files-all)

--- a/src/fpcore-extra.rkt
+++ b/src/fpcore-extra.rkt
@@ -8,6 +8,7 @@
          fpcore-split-or fpcore-all-subexprs fpcore-split-intervals
          fpcore-unroll-loops fpcore-skip-loops
          fpcore-expand-let* fpcore-expand-while* fpcore-precondition-ranges
+         fpcore-override-props fpcore-override-arg-precision
          fpcore-transform
          fpcore-name)
 
@@ -478,13 +479,38 @@
                    (append progs
                            (loop (cons new-pre pre-list) new-name (cdr vars))))]))))))
 
+(define/contract (fpcore-override-arg-precision prec prog)
+  ; Adds (! :precision prec) to all arguments
+  (-> symbol? fpcore? fpcore?)
+  (define/match (transform-arg arg)
+    [((list '! props ... name)) `(! ,@(append props `(:precision ,prec)) ,name)]
+    [(name) `(! :precision ,prec ,name)])
+  (match prog
+    [(list 'FPCore (list args ...) props ... body)
+      `(FPCore ,(map transform-arg args) ,@props ,body)]
+    [(list 'FPCore name (list args ...) props ... body)
+      `(FPCore ,name ,(map transform-arg args) ,@props ,body)]))
+
+(define/contract (fpcore-override-props new-props prog)
+  ; Adds given properties to the core
+  (-> (listof symbol?) fpcore? fpcore?)
+  (match prog
+    [(list 'FPCore (? list? args) props ... body)
+      `(FPCore ,args ,@props ,@new-props ,body)]
+    [(list 'FPCore name (? list? args) props ... body)
+      `(FPCore ,name ,args ,@props ,@new-props ,body)]))
+
 (define/contract (fpcore-transform prog
+                                   #:var-precision [var-precision #f]
+                                   #:override-props [override-props #f]
                                    #:unroll [unroll #f]
                                    #:split [split #f]
                                    #:split-or [split-or #f]
                                    #:subexprs [subexprs #f])
   (->* (fpcore?)
-       (#:unroll (or/c #f exact-nonnegative-integer?)
+       (#:var-precision (or/c #f symbol?)
+        #:override-props (or/c #f (listof symbol?))
+        #:unroll (or/c #f exact-nonnegative-integer?)
         #:split (or/c #f exact-nonnegative-integer?)
         #:split-or boolean?
         #:subexprs boolean?)
@@ -493,6 +519,8 @@
     (if cond (append-map f progs) progs))
   (define transform
     (compose
+     (make-t var-precision (compose list (curry fpcore-override-arg-precision var-precision)))
+     (make-t override-props (compose list (curry fpcore-override-props override-props)))
      (make-t subexprs fpcore-all-subexprs)
      (make-t split (curry fpcore-split-intervals split))
      (make-t split-or fpcore-split-or)

--- a/src/fpcore-extra.rkt
+++ b/src/fpcore-extra.rkt
@@ -471,7 +471,7 @@
                  (define properties* (dict-set* properties ':pre pre* ':name name*))
                  `((FPCore ,args ,@(unparse-properties properties*) ,body))]
                 [else
-                 (match-define (cons var (interval a b #t #t)) (car vars))
+                 (match-define (list var (interval a b #t #t)) (car vars))
                  (define step (/ (- b a) splits))
                  (for/fold [(progs '())] [(i (in-range splits))]
                    (define new-pre `(<= ,(+ a (* i step)) ,var ,(+ a (* (+ i 1) step))))

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -348,11 +348,12 @@
       (for/lists (n p) ([var args])
         (match var
           [(list '! props ... name) 
-            (values 
-                (let-values ([(cx name) (ctx-unique-name ctx name)])
+            (let ([props* (apply hash-set* (ctx-props ctx) props)])
+              (values 
+                (let-values ([(cx name) (ctx-unique-name ctx name (dict-ref props* ':precision 'binary64))])
                             (set! ctx cx)
                             name)
-                (apply hash-set* (ctx-props ctx) props))]
+                props*))]
           [name 
             (values 
                 (let-values ([(cx name) (ctx-unique-name ctx name)])

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -20,7 +20,7 @@
 
 (define (convert-declaration ctx var [val #f])
   (define val* (if (string? val) (trim-infix-parens val) val))
-  (if (equal? (language-name (*lang*)) "sollya")
+  (if (set-member? '("sollya" "fptaylor") (language-name (*lang*)))
       ((language-assignment (*lang*)) var val*)
       ((language-declaration (*lang*)) (ctx-props ctx) var val*)))
     
@@ -29,7 +29,7 @@
   ((language-assignment (*lang*)) var val*))
 
 (define (round-expr expr ctx [all? #f]) ; Sollya will never ignore but C can
-  (if (or all? (equal? (language-name (*lang*)) "sollya"))
+  (if (or all? (set-member? '("sollya" "fptaylor") (language-name (*lang*))))
       ((language-round (*lang*)) expr (ctx-props ctx))
       expr))
 

--- a/src/range-analysis.rkt
+++ b/src/range-analysis.rkt
@@ -50,8 +50,8 @@
      (cond [(< u1 u2) u1?]
            [(= u1 u2) (and u1? u2?)]
            [(> u1 u2) u2?]))
-    (define l (max l1 l2))
-    (define u (min u1 u2))
+    (define l (exact-max l1 l2))
+    (define u (exact-min u1 u2))
 
     (make-interval l u l? u?)]
    [else #f]))
@@ -87,8 +87,8 @@
      (cond [(< u1 u2) u2?]
            [(= u1 u2) (or u1? u2?)]
            [(> u1 u2) u1?]))
-    (define l (min l1 l2))
-    (define u (max u1 u2))
+    (define l (exact-min l1 l2))
+    (define u (exact-max u1 u2))
 
     (make-interval l u l? u?)]
    [interval1 interval1]
@@ -367,18 +367,18 @@
   (check-equal? (condition->range-table '(< 1 2)) (make-hash))
   (check-equal? (condition->range-table '(< x 1)) (make-hash (list (list 'x (interval -inf.0 1 #f #f)))))
   (check-equal? (condition->range-table '(< x y 2)) (make-hash (list (list 'x (interval -inf.0 2 #f #f)) (list 'y (interval -inf.0 2 #f #f)))))
-  (check-equal? (condition->range-table '(< 1 x y 2)) (make-hash (list (list 'x (interval 1.0 2.0 #f #f)) (list 'y (interval 1.0 2.0 #f #f)))))
+  (check-equal? (condition->range-table '(< 1 x y 2)) (make-hash (list (list 'x (interval 1 2 #f #f)) (list 'y (interval 1 2 #f #f)))))
   (check-equal? (range-table-ref (condition->range-table '(< 1 2 3)) 'x) (list (interval -inf.0 +inf.0 #f #f)))
   (check-equal? (range-table-ref (condition->range-table '(< 10 2 3)) 'x) '())
   (check-equal? (range-table-ref (condition->range-table '(< 0 x 4 3)) 'x) '())
-  (check-equal? (condition->range-table '(and (< x 1) (> x -1))) (make-hash (list (list 'x (interval -1.0 1.0 #f #f)))))
+  (check-equal? (condition->range-table '(and (< x 1) (> x -1))) (make-hash (list (list 'x (interval -1 1 #f #f)))))
   (check-equal? (condition->range-table '(or (< x 1) (> x -1))) (make-hash (list (list 'x (interval -inf.0 +inf.0 #f #f)))))
   (check-equal? (condition->range-table '(or (< x -1) (> x 1))) (make-hash (list (list 'x (interval -inf.0 -1 #f #f) (interval 1 +inf.0 #f #f)))))
   (check-equal? (condition->range-table '(or (< x 1) (< x 2) (> x -1))) (make-hash (list (list 'x (interval -inf.0 +inf.0 #f #f)))))
-  (check-equal? (condition->range-table '(and (< x 1) (< x 2) (> x -1))) (make-hash (list (list 'x (interval -1.0 1.0 #f #f)))))
+  (check-equal? (condition->range-table '(and (< x 1) (< x 2) (> x -1))) (make-hash (list (list 'x (interval -1 1 #f #f)))))
   (check-equal? (condition->range-table '(not (< x 1))) (make-hash (list (list 'x (interval 1 +inf.0 #t #f)))))
   (check-equal? (condition->range-table '(not (> x 1))) (make-hash (list (list 'x (interval -inf.0 1 #f #t)))))
-  (check-equal? (condition->range-table '(and (not (> x 1)) (not (< x -2)))) (make-hash (list (list 'x (interval -2.0 1.0 #t #t)))))
+  (check-equal? (condition->range-table '(and (not (> x 1)) (not (< x -2)))) (make-hash (list (list 'x (interval -2 1 #t #t)))))
   ; this following two test tells us that we could have two representations of empty range-table
   ; therefore we use range-table-ref to hide the internal representation of range-table
   (check-equal? (range-table-ref (condition->range-table '(or (not (> x 1)) (not (< x -2)))) 'x) (list (interval -inf.0 +inf.0 #f #f)))

--- a/tests/metadata.fpcore
+++ b/tests/metadata.fpcore
@@ -147,11 +147,3 @@
  (let ([x 0x1p0]
        [y 0x1p-30])
   (! :precision binary64 (+ x y))))
-
-(FPCore ((! :precision binary32 x))
-  :name "monadius args"
-  :description "v should have the same precision as x"
-  :precision binary64
-  :pre (<= 1 x 20)
-  (let ((v x))
-    (+ v v)))

--- a/tests/metadata.fpcore
+++ b/tests/metadata.fpcore
@@ -147,3 +147,9 @@
  (let ([x 0x1p0]
        [y 0x1p-30])
   (! :precision binary64 (+ x y))))
+
+(FPCore ((! :precision binary32 x) y)
+  :description "v should have the same precision as x"
+  :precision binary64
+  (let ((v x))
+    (+ v y)))

--- a/tests/metadata.fpcore
+++ b/tests/metadata.fpcore
@@ -148,8 +148,10 @@
        [y 0x1p-30])
   (! :precision binary64 (+ x y))))
 
-(FPCore ((! :precision binary32 x) y)
+(FPCore ((! :precision binary32 x))
+  :name "monadius args"
   :description "v should have the same precision as x"
   :precision binary64
+  :pre (<= 1 x 20)
   (let ((v x))
-    (+ v y)))
+    (+ v v)))

--- a/tests/sanity/numbers.fpcore
+++ b/tests/sanity/numbers.fpcore
@@ -30,11 +30,11 @@
 
 (FPCore () :name "Test rational (5/5)" :spec 1.25 5/4)
 
-(FPCore () :name "Test digits (1/4)" :spec 0.0 (digits 0 0 2))
+(FPCore () :name "Test digits (1/4)" :spec 0 (digits 0 0 2))
 
-(FPCore () :name "Test digits (2/4)" :spec 1.0 (digits 1 0 2))
+(FPCore () :name "Test digits (2/4)" :spec 1 (digits 1 0 2))
 
-(FPCore () :name "Test digits (3/4)" :spec -2.0 (digits -1 1 2))
+(FPCore () :name "Test digits (3/4)" :spec -2 (digits -1 1 2))
 
-(FPCore () :name "Test digits (4/4)" :spec 1.5 (digits 3 -1 2))
+(FPCore () :name "Test digits (4/4)" :spec 3/2 (digits 3 -1 2))
 

--- a/tests/scripts/test-export.out.txt
+++ b/tests/scripts/test-export.out.txt
@@ -91,34 +91,31 @@ ex2 float<ieee_64,ne>= (arg01 - arg11);
 
 {
 Variables
-	real arg0 in [1, 10];
-	real arg1 in [1, 10];
+	float64 arg0 in [1, 10];
+	float64 arg1 in [1, 10];
 
 Expressions
-	$43$ rnd64= (arg0 + arg1);
+	_43_ = rnd64(arg0 + arg1);
 }
-
 {
 Variables
-	real arg0 in [0, 10];
+	float64 arg0 in [0, 10];
 
 Expressions
-	sqrt rnd64= sqrt(arg0);
+	sqrt_1 = rnd64(sqrt(arg0));
 }
-
 {
 Variables
-	real arg0 in [1, 10];
-	real arg1 in [1, 10];
+	float64 arg0 in [1, 10];
+	float64 arg1 in [1, 10];
 
 Definitions
-	arg01 rnd64= arg1;
-	arg11 rnd64= arg0;
+	arg0_1 = arg1;
+	arg1_2 = arg0;
 
 Expressions
-	let rnd64= (arg01 - arg11);
+	let = rnd64(arg0_1 - arg1_2);
 }
-
 ex0[arg0_, arg1_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, (arg0 + arg1)]
 
 ex1[arg0_] := Block[{$MinPrecision=MachinePrecision, $MaxPrecision=MachinePrecision, $MaxExtraPrecision=0}, Sqrt[arg0]]

--- a/tests/scripts/test-transform.out.txt
+++ b/tests/scripts/test-transform.out.txt
@@ -35,7 +35,7 @@
  :name
  "Test while"
  :pre
- (and (< 1.0 arg1 10.0))
+ (and (< 1 arg1 10))
  (while*
   (<= a 3)
   ((a 0 (+ a 1)) (b 0 (+ arg1 a)))


### PR DESCRIPTION
A new FPTaylor compiler which supports precision annotations. This new compiler is based on the Sollya compiler.

I also updated the version of FPTaylor in tests.

Other changes:
- Using `exact-max` and `exact-min` in `range-analysis.rkt`.
- `imperative.rkt`: the precision of annotated arguments is added to the context. I initially added the following test case:
  ```racket
  (FPCore ((! :precision binary32 x))
    :name "monadius args"
    :description "v should have the same precision as x"
    :precision binary64
    :pre (<= 1 x 20)
    (let ((v x)) (+ v v)))
  ```
  But Z3 and CakeML tests did not pass this test case. So this test case is not included in the PR.