### PR TITLE
Eigenvalue calculation benchmark adapted from TNG (at Intel graphics).

### DIFF
--- a/benchmarks/graphics.fpcore
+++ b/benchmarks/graphics.fpcore
@@ -1,0 +1,8 @@
+;; -*- mode: scheme -*-
+
+(FPCore (a b c d)
+        :name "some eigenvalue calculation"
+        :fpbench-domain graphics
+        ;; that's some calculation
+        (- (sqrt (+ (pow (+ a d) 2) (pow (- b c) 2)))
+           (sqrt (+ (pow (- a d) 2) (pow (+ b c) 2)))))


### PR DESCRIPTION
This benchmark is an interesting case for Herbie, or any rewrite based optimization tool.

Naively, the calculation looks like:
sqrt( (a+d)^2 + (b-c)^2 ) - sqrt( (a-d)^2 + (b+c)^2 )

This can be rewritten:

sos = a^2 + b^2 + c^2 + d^2
det = ad - bc
sqrt(sos + 2 det) - sqrt(sos - 2 det)

This is much more stable numerically; the hard part is isolated to computing the determinant. If the determinant is small relative to the sum of squares, we can use a series expansion of the expression:

sqrt(x + y) - sqrt(x - y) ~= y / sqrt(x)

near x = inf, to rewrite the whole expression as:

det / sqrt(sos)

in that regime, and avoid cancellation that would otherwise happen in the subtraction.

This is challenging for regime discovery, because the expression that determines the regime (namely, the determinant compared to the sum of squares) is some combination of all the inputs, which does not even occur naturally in the original expression.


