### PR TITLE
Adds sanity tests for fmin/fmax

### DIFF
--- a/infra/test-core2ocaml.rkt
+++ b/infra/test-core2ocaml.rkt
@@ -10,7 +10,7 @@
         (match prog
          [(list 'FPCore (list args ...) rest ...) (length args)]
          [(list 'FPCore name (list args ...) rest ...) (length args)]))
-      (fprintf p "~a\n\n" (core->ocaml prog "f"))
+      (fprintf p "~a~a\n" (ocaml-header) (core->ocaml prog "f"))
       (fprintf p "let _ =\n  Printf.printf \"%.17g\" (f ~a)\n"
         (if (zero? N)
             "()"

--- a/src/core2fptaylor.rkt
+++ b/src/core2fptaylor.rkt
@@ -12,7 +12,7 @@
       (curry set-member?
              '(atan2 cbrt ceil copysign erf erfc exp2 expm1 fdim floor fmod hypot if 
               lgamma log10 log1p log2 nearbyint pow remainder round tgamma trunc while while*)))
-    fpcore-consts
+    (invert-const-proc (curry set-member? '(NAN INFINITY)))
     (curry set-member? '(binary16 binary32 binary64 binary128 real))
     ; Note: nearestEven and nearestAway behave identically in FPTaylor
     ieee754-rounding-modes))

--- a/src/core2java.rkt
+++ b/src/core2java.rkt
@@ -9,7 +9,14 @@
 (define java-math-lib (make-parameter "Math"))
 
 (define (java-header namespace)
-  (format "import java.lang.*;\n\npublic class ~a {\n\n" namespace))
+  (string-append
+    (format "import java.lang.*;\n\npublic class ~a {\n\n" namespace)
+    "public static double fmin(double x, double y) {\n"
+    (format "\treturn (Double.isNaN(x) ? y : (Double.isNaN(y) ? x : (~a.min(x, y))));\n}\n\n"
+            (java-math-lib))
+    "public static double fmax(double x, double y) {\n"
+    (format "\treturn (Double.isNaN(x) ? y : (Double.isNaN(y) ? x : (~a.max(x, y))));\n}\n\n"
+            (java-math-lib))))
 
 (define java-footer
   (const "}\n"))
@@ -55,8 +62,8 @@
    ['isfinite (format "(!~a.isNaN(~a) && !~a.isInfinite(~a))" class args* class args*)]
    ['copysign (format "~a.copySign(~a)" (java-math-lib) args*)]
    ['fabs (format "~a.abs(~a)" (java-math-lib) args*)]
-   ['fmax (format "~a.max(~a)" (java-math-lib) args*)]
-   ['fmin (format "~a.min(~a)" (java-math-lib) args*)]
+   ['fmax (format "fmax(~a)" args*)]
+   ['fmin (format "fmin(~a)" args*)]
    ['remainder (format "~a.IEEEremainder(~a)" (java-math-lib) args*)]
    [_ (format "~a.~a(~a)" (java-math-lib) op args*)]))
 

--- a/src/core2ocaml.rkt
+++ b/src/core2ocaml.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "ml.rkt")
-(provide core->ocaml ocaml-supported)
+(provide core->ocaml ocaml-header ocaml-supported)
 
 ; 'cast' is a no-op since only one precision is supported
 (define ocaml-supported
@@ -21,6 +21,12 @@
     match method mod module mutable new nonrec object of open
     or private rec sig struct then to true try type val virtual
     when while with))
+
+(define ocaml-header
+  (const
+    (string-append
+      "let fmax x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.max x y)\n\n"
+      "let fmin x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.min x y)\n\n")))
 
 (define (fix-name name)
   (apply string-append
@@ -53,8 +59,8 @@
      ['isnormal (format "((Float.classify_float ~a) == Float.FP_normal)" args*)]
      ['signbit (format "(Float.sign_bit ~a)" args*)]
      ['fabs (format "(Float.abs ~a)" args*)]
-     ['fmax (format "(Float.max ~a)" args*)]
-     ['fmin (format "(Float.min ~a)" args*)]
+     ['fmax (format "(fmax ~a)" args*)]
+     ['fmin (format "(fmin ~a)" args*)]
      ['fmod (format "(Float.rem ~a)" args*)]
      ['copysign (format "(Float.copy_sign ~a)" args*)]
      [_ (format "(Float.~a ~a)" op args*)])]))
@@ -181,4 +187,4 @@
     #:visitor ocaml-visitor
     #:fix-name fix-name))
 
-(define-compiler '("ocaml" "ml") (const "") core->ocaml (const "") ocaml-supported)
+(define-compiler '("ocaml" "ml") ocaml-header core->ocaml (const "") ocaml-supported)

--- a/tests/sanity/ops.fpcore
+++ b/tests/sanity/ops.fpcore
@@ -162,17 +162,25 @@
 
 (FPCore () :name "Test remainder (3/3)" :spec -1.0 (remainder 3 2))
 
-(FPCore () :name "Test fmax (1/3)" :spec 1.0 (fmax 1.0 0.0))
+(FPCore () :name "Test fmax (1/5)" :spec 1.0 (fmax 1.0 0.0))
 
-(FPCore () :name "Test fmax (2/3)" :spec 0.0 (fmax -1.0 0.0))
+(FPCore () :name "Test fmax (2/5)" :spec 0.0 (fmax -1.0 0.0))
 
-(FPCore () :name "Test fmax (3/3)" :spec 1.0 (fmax 1.0 -1.0))
+(FPCore () :name "Test fmax (3/5)" :spec 1.0 (fmax 1.0 -1.0))
 
-(FPCore () :name "Test fmin (1/3)" :spec 0.0 (fmin 1.0 0.0))
+(FPCore () :name "Test fmax (4/5)" :spec 1.0 (fmax 1.0 NAN))
 
-(FPCore () :name "Test fmin (2/3)" :spec -1.0 (fmin -1.0 0.0))
+(FPCore () :name "Test fmax (5/5)" :spec 1.0 (fmax NAN 1.0))
 
-(FPCore () :name "Test fmin (3/3)" :spec -1.0 (fmin 1.0 -1.0))
+(FPCore () :name "Test fmin (1/5)" :spec 0.0 (fmin 1.0 0.0))
+
+(FPCore () :name "Test fmin (2/5)" :spec -1.0 (fmin -1.0 0.0))
+
+(FPCore () :name "Test fmin (3/5)" :spec -1.0 (fmin 1.0 -1.0))
+
+(FPCore () :name "Test fmin (4/5)" :spec 1.0 (fmin 1.0 NAN))
+
+(FPCore () :name "Test fmin (5/5)" :spec 1.0 (fmin NAN 1.0))
 
 (FPCore () :name "Test fdim (1/3)" :spec 1.0 (fdim 2.0 1.0))
 


### PR DESCRIPTION
In most languages (compared to C), the `fmin` and `fmax` functions have different behavior when it comes to `NaN` arguments. The C99 standard states that these functions treat `NaN` as missing data, so it will return the other argument if they encounter a `NaN`. Most languages prefer to return `NaN` if any argument is `NaN`. This PR just adds a few sanity tests to check this behavior, and fixes some compilers that did not translate this correctly.