### PR TITLE
Add missing boolean operator tests

### DIFF
--- a/src/core2ocaml.rkt
+++ b/src/core2ocaml.rkt
@@ -25,7 +25,6 @@
 (define ocaml-header
   (const
     (string-append
-      "let ieee754_eq x y = if ((Float.is_nan x) && (Float.is_nan y)) then false else (x = y)\n\n"
       "let c_fmax x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.max x y)\n\n"
       "let c_fmin x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.min x y)\n\n")))
 
@@ -40,14 +39,14 @@
   (format "(~a)"
           (string-join
             (for/list ([a (cons x xs)] [b xs])
-              (format "(ieee754_eq ~a ~a)" a b))
+              (format "(~a = ~a)" a b))
             " && ")))
 
 (define (inequality->ocaml x xs)
   (format "(not (~a))"
           (string-join
             (for/list ([a (cons x xs)] [b xs])
-              (format "(ieee754_eq ~a ~a)" a b))
+              (format "(~a = ~a)" a b))
             " || ")))
 
 (define (operator->ocaml op args ctx)

--- a/src/core2ocaml.rkt
+++ b/src/core2ocaml.rkt
@@ -25,8 +25,9 @@
 (define ocaml-header
   (const
     (string-append
-      "let fmax x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.max x y)\n\n"
-      "let fmin x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.min x y)\n\n")))
+      "let ieee754_eq x y = if ((Float.is_nan x) && (Float.is_nan y)) then false else (x = y)\n\n"
+      "let c_fmax x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.max x y)\n\n"
+      "let c_fmin x y = if (Float.is_nan x) then y else if (Float.is_nan y) then x else (Float.min x y)\n\n")))
 
 (define (fix-name name)
   (apply string-append
@@ -39,8 +40,15 @@
   (format "(~a)"
           (string-join
             (for/list ([a (cons x xs)] [b xs])
-              (format "(~a = ~a)" a b))
+              (format "(ieee754_eq ~a ~a)" a b))
             " && ")))
+
+(define (inequality->ocaml x xs)
+  (format "(not (~a))"
+          (string-join
+            (for/list ([a (cons x xs)] [b xs])
+              (format "(ieee754_eq ~a ~a)" a b))
+            " || ")))
 
 (define (operator->ocaml op args ctx)
   (match (cons op args)
@@ -50,6 +58,7 @@
    [(list '* a b) (format "(Float.mul ~a ~a)" a b)]
    [(list '/ a b) (format "(Float.div ~a ~a)" a b)]
    [(list '== arg args ...) (equality->ocaml arg args)]
+   [(list '!= arg args ...) (inequality->ocaml arg args)]
    [_
     (define args* (string-join args " "))
     (match op
@@ -59,8 +68,8 @@
      ['isnormal (format "((Float.classify_float ~a) == Float.FP_normal)" args*)]
      ['signbit (format "(Float.sign_bit ~a)" args*)]
      ['fabs (format "(Float.abs ~a)" args*)]
-     ['fmax (format "(fmax ~a)" args*)]
-     ['fmin (format "(fmin ~a)" args*)]
+     ['fmax (format "(c_fmax ~a)" args*)]
+     ['fmin (format "(c_fmin ~a)" args*)]
      ['fmod (format "(Float.rem ~a)" args*)]
      ['copysign (format "(Float.copy_sign ~a)" args*)]
      [_ (format "(Float.~a ~a)" op args*)])]))
@@ -180,7 +189,7 @@
 
 (define core->ocaml
   (make-ml-compiler "ocaml"
-    #:infix-ops (remove* '(+ - * / ==) default-infix-ops)
+    #:infix-ops (remove* '(+ - * / == !=) default-infix-ops)
     #:operator operator->ocaml
     #:constant constant->ocaml
     #:program program->ocaml

--- a/src/ml.rkt
+++ b/src/ml.rkt
@@ -1,6 +1,6 @@
 ;
 ;   Common compiler for ML languages
-;     CakeML, OCaml
+;     CakeML, OCaml, Haskell
 ;
 
 #lang racket

--- a/tests/sanity/bool-ops.fpcore
+++ b/tests/sanity/bool-ops.fpcore
@@ -1,66 +1,74 @@
-(FPCore () :name "Test < (1/8)" :spec 0.0 (if (< 1.0 0.0) 1 0))
+(FPCore () :name "Test < (1/9)" :spec 0.0 (if (< 1.0 0.0) 1 0))
 
-(FPCore () :name "Test < (2/8)" :spec 1.0 (if (< 0.0 1.0) 1 0))
+(FPCore () :name "Test < (2/9)" :spec 1.0 (if (< 0.0 1.0) 1 0))
 
-(FPCore () :name "Test < (3/8)" :spec 1.0 (if (< -1.0 0.0) 1 0))
+(FPCore () :name "Test < (3/9)" :spec 1.0 (if (< -1.0 0.0) 1 0))
 
-(FPCore () :name "Test < (4/8)" :spec 0.0 (if (< 0.0 -1.0) 1 0))
+(FPCore () :name "Test < (4/9)" :spec 0.0 (if (< 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test < (5/8)" :spec 0.0 (if (< 1.0 -1.0) 1 0))
+(FPCore () :name "Test < (5/9)" :spec 0.0 (if (< 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test < (6/8)" :spec 1.0 (if (< -1.0 1.0) 1 0))
+(FPCore () :name "Test < (6/9)" :spec 1.0 (if (< -1.0 1.0) 1 0))
 
-(FPCore () :name "Test < (7/8)" :spec 0.0 (if (< 0.0 0.0) 1 0))
+(FPCore () :name "Test < (7/9)" :spec 0.0 (if (< 0.0 0.0) 1 0))
 
-(FPCore () :name "Test < (8/8)" :spec 0.0 (if (< 0.0 0.0 0.0) 1 0))
+(FPCore () :name "Test < (8/9)" :spec 0.0 (if (< NAN NAN) 1 0))
 
-(FPCore () :name "Test > (1/8)" :spec 1.0 (if (> 1.0 0.0) 1 0))
+(FPCore () :name "Test < (9/9)" :spec 0.0 (if (< 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test > (2/8)" :spec 0.0 (if (> 0.0 1.0) 1 0))
+(FPCore () :name "Test > (1/9)" :spec 1.0 (if (> 1.0 0.0) 1 0))
 
-(FPCore () :name "Test > (3/8)" :spec 0.0 (if (> -1.0 0.0) 1 0))
+(FPCore () :name "Test > (2/9)" :spec 0.0 (if (> 0.0 1.0) 1 0))
 
-(FPCore () :name "Test > (4/8)" :spec 1.0 (if (> 0.0 -1.0) 1 0))
+(FPCore () :name "Test > (3/9)" :spec 0.0 (if (> -1.0 0.0) 1 0))
 
-(FPCore () :name "Test > (5/8)" :spec 1.0 (if (> 1.0 -1.0) 1 0))
+(FPCore () :name "Test > (4/9)" :spec 1.0 (if (> 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test > (6/8)" :spec 0.0 (if (> -1.0 1.0) 1 0))
+(FPCore () :name "Test > (5/9)" :spec 1.0 (if (> 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test > (7/8)" :spec 0.0 (if (> 0.0 0.0) 1 0))
+(FPCore () :name "Test > (6/9)" :spec 0.0 (if (> -1.0 1.0) 1 0))
 
-(FPCore () :name "Test > (8/8)" :spec 0.0 (if (> 0.0 0.0 0.0) 1 0))
+(FPCore () :name "Test > (7/9)" :spec 0.0 (if (> 0.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (1/8)" :spec 0.0 (if (<= 1.0 0.0) 1 0))
+(FPCore () :name "Test > (8/9)" :spec 0.0 (if (> NAN NAN) 1 0))
 
-(FPCore () :name "Test <= (2/8)" :spec 1.0 (if (<= 0.0 1.0) 1 0))
+(FPCore () :name "Test > (9/9)" :spec 0.0 (if (> 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (3/8)" :spec 1.0 (if (<= -1.0 0.0) 1 0))
+(FPCore () :name "Test <= (1/9)" :spec 0.0 (if (<= 1.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (4/8)" :spec 0.0 (if (<= 0.0 -1.0) 1 0))
+(FPCore () :name "Test <= (2/9)" :spec 1.0 (if (<= 0.0 1.0) 1 0))
 
-(FPCore () :name "Test <= (5/8)" :spec 0.0 (if (<= 1.0 -1.0) 1 0))
+(FPCore () :name "Test <= (3/9)" :spec 1.0 (if (<= -1.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (6/8)" :spec 1.0 (if (<= -1.0 1.0) 1 0))
+(FPCore () :name "Test <= (4/9)" :spec 0.0 (if (<= 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test <= (7/8)" :spec 1.0 (if (<= 0.0 0.0) 1 0))
+(FPCore () :name "Test <= (5/9)" :spec 0.0 (if (<= 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test <= (8/8)" :spec 1.0 (if (<= 0.0 0.0 0.0) 1 0))
+(FPCore () :name "Test <= (6/9)" :spec 1.0 (if (<= -1.0 1.0) 1 0))
 
-(FPCore () :name "Test >= (1/8)" :spec 1.0 (if (>= 1.0 0.0) 1 0))
+(FPCore () :name "Test <= (7/9)" :spec 1.0 (if (<= 0.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (2/8)" :spec 0.0 (if (>= 0.0 1.0) 1 0))
+(FPCore () :name "Test <= (8/9)" :spec 0.0 (if (<= NAN NAN) 1 0))
 
-(FPCore () :name "Test >= (3/8)" :spec 0.0 (if (>= -1.0 0.0) 1 0))
+(FPCore () :name "Test <= (9/9)" :spec 1.0 (if (<= 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (4/8)" :spec 1.0 (if (>= 0.0 -1.0) 1 0))
+(FPCore () :name "Test >= (1/9)" :spec 1.0 (if (>= 1.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (5/8)" :spec 1.0 (if (>= 1.0 -1.0) 1 0))
+(FPCore () :name "Test >= (2/9)" :spec 0.0 (if (>= 0.0 1.0) 1 0))
 
-(FPCore () :name "Test >= (6/8)" :spec 0.0 (if (>= -1.0 1.0) 1 0))
+(FPCore () :name "Test >= (3/9)" :spec 0.0 (if (>= -1.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (7/8)" :spec 1.0 (if (>= 0.0 0.0) 1 0))
+(FPCore () :name "Test >= (4/9)" :spec 1.0 (if (>= 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test >= (8/8)" :spec 1.0 (if (>= 0.0 0.0 0.0) 1 0))
+(FPCore () :name "Test >= (5/9)" :spec 1.0 (if (>= 1.0 -1.0) 1 0))
+
+(FPCore () :name "Test >= (6/9)" :spec 0.0 (if (>= -1.0 1.0) 1 0))
+
+(FPCore () :name "Test >= (7/9)" :spec 1.0 (if (>= 0.0 0.0) 1 0))
+
+(FPCore () :name "Test >= (8/9)" :spec 0.0 (if (>= NAN NAN) 1 0))
+
+(FPCore () :name "Test >= (9/9)" :spec 1.0 (if (>= 0.0 0.0 0.0) 1 0))
 
 (FPCore () :name "Test == (1/9)" :spec 0.0 (if (== 1.0 0.0) 1 0))
 

--- a/tests/sanity/bool-ops.fpcore
+++ b/tests/sanity/bool-ops.fpcore
@@ -1,90 +1,102 @@
-(FPCore () :name "Test < (1/7)" :spec 0.0 (if (< 1.0 0.0) 1 0))
+(FPCore () :name "Test < (1/8)" :spec 0.0 (if (< 1.0 0.0) 1 0))
 
-(FPCore () :name "Test < (2/7)" :spec 1.0 (if (< 0.0 1.0) 1 0))
+(FPCore () :name "Test < (2/8)" :spec 1.0 (if (< 0.0 1.0) 1 0))
 
-(FPCore () :name "Test < (3/7)" :spec 1.0 (if (< -1.0 0.0) 1 0))
+(FPCore () :name "Test < (3/8)" :spec 1.0 (if (< -1.0 0.0) 1 0))
 
-(FPCore () :name "Test < (4/7)" :spec 0.0 (if (< 0.0 -1.0) 1 0))
+(FPCore () :name "Test < (4/8)" :spec 0.0 (if (< 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test < (5/7)" :spec 0.0 (if (< 1.0 -1.0) 1 0))
+(FPCore () :name "Test < (5/8)" :spec 0.0 (if (< 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test < (6/7)" :spec 1.0 (if (< -1.0 1.0) 1 0))
+(FPCore () :name "Test < (6/8)" :spec 1.0 (if (< -1.0 1.0) 1 0))
 
-(FPCore () :name "Test < (7/7)" :spec 0.0 (if (< 0.0 0.0) 1 0))
+(FPCore () :name "Test < (7/8)" :spec 0.0 (if (< 0.0 0.0) 1 0))
 
-(FPCore () :name "Test > (1/7)" :spec 1.0 (if (> 1.0 0.0) 1 0))
+(FPCore () :name "Test < (8/8)" :spec 0.0 (if (< 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test > (2/7)" :spec 0.0 (if (> 0.0 1.0) 1 0))
+(FPCore () :name "Test > (1/8)" :spec 1.0 (if (> 1.0 0.0) 1 0))
 
-(FPCore () :name "Test > (3/7)" :spec 0.0 (if (> -1.0 0.0) 1 0))
+(FPCore () :name "Test > (2/8)" :spec 0.0 (if (> 0.0 1.0) 1 0))
 
-(FPCore () :name "Test > (4/7)" :spec 1.0 (if (> 0.0 -1.0) 1 0))
+(FPCore () :name "Test > (3/8)" :spec 0.0 (if (> -1.0 0.0) 1 0))
 
-(FPCore () :name "Test > (5/7)" :spec 1.0 (if (> 1.0 -1.0) 1 0))
+(FPCore () :name "Test > (4/8)" :spec 1.0 (if (> 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test > (6/7)" :spec 0.0 (if (> -1.0 1.0) 1 0))
+(FPCore () :name "Test > (5/8)" :spec 1.0 (if (> 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test > (7/7)" :spec 0.0 (if (> 0.0 0.0) 1 0))
+(FPCore () :name "Test > (6/8)" :spec 0.0 (if (> -1.0 1.0) 1 0))
 
-(FPCore () :name "Test <= (1/7)" :spec 0.0 (if (<= 1.0 0.0) 1 0))
+(FPCore () :name "Test > (7/8)" :spec 0.0 (if (> 0.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (2/7)" :spec 1.0 (if (<= 0.0 1.0) 1 0))
+(FPCore () :name "Test > (8/8)" :spec 0.0 (if (> 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (3/7)" :spec 1.0 (if (<= -1.0 0.0) 1 0))
+(FPCore () :name "Test <= (1/8)" :spec 0.0 (if (<= 1.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (4/7)" :spec 0.0 (if (<= 0.0 -1.0) 1 0))
+(FPCore () :name "Test <= (2/8)" :spec 1.0 (if (<= 0.0 1.0) 1 0))
 
-(FPCore () :name "Test <= (5/7)" :spec 0.0 (if (<= 1.0 -1.0) 1 0))
+(FPCore () :name "Test <= (3/8)" :spec 1.0 (if (<= -1.0 0.0) 1 0))
 
-(FPCore () :name "Test <= (6/7)" :spec 1.0 (if (<= -1.0 1.0) 1 0))
+(FPCore () :name "Test <= (4/8)" :spec 0.0 (if (<= 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test <= (7/7)" :spec 1.0 (if (<= 0.0 0.0) 1 0))
+(FPCore () :name "Test <= (5/8)" :spec 0.0 (if (<= 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test >= (1/7)" :spec 1.0 (if (>= 1.0 0.0) 1 0))
+(FPCore () :name "Test <= (6/8)" :spec 1.0 (if (<= -1.0 1.0) 1 0))
 
-(FPCore () :name "Test >= (2/7)" :spec 0.0 (if (>= 0.0 1.0) 1 0))
+(FPCore () :name "Test <= (7/8)" :spec 1.0 (if (<= 0.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (3/7)" :spec 0.0 (if (>= -1.0 0.0) 1 0))
+(FPCore () :name "Test <= (8/8)" :spec 1.0 (if (<= 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (4/7)" :spec 1.0 (if (>= 0.0 -1.0) 1 0))
+(FPCore () :name "Test >= (1/8)" :spec 1.0 (if (>= 1.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (5/7)" :spec 1.0 (if (>= 1.0 -1.0) 1 0))
+(FPCore () :name "Test >= (2/8)" :spec 0.0 (if (>= 0.0 1.0) 1 0))
 
-(FPCore () :name "Test >= (6/7)" :spec 0.0 (if (>= -1.0 1.0) 1 0))
+(FPCore () :name "Test >= (3/8)" :spec 0.0 (if (>= -1.0 0.0) 1 0))
 
-(FPCore () :name "Test >= (7/7)" :spec 1.0 (if (>= 0.0 0.0) 1 0))
+(FPCore () :name "Test >= (4/8)" :spec 1.0 (if (>= 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test == (1/8)" :spec 0.0 (if (== 1.0 0.0) 1 0))
+(FPCore () :name "Test >= (5/8)" :spec 1.0 (if (>= 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test == (2/8)" :spec 0.0 (if (== 0.0 1.0) 1 0))
+(FPCore () :name "Test >= (6/8)" :spec 0.0 (if (>= -1.0 1.0) 1 0))
 
-(FPCore () :name "Test == (3/8)" :spec 0.0 (if (== -1.0 0.0) 1 0))
+(FPCore () :name "Test >= (7/8)" :spec 1.0 (if (>= 0.0 0.0) 1 0))
 
-(FPCore () :name "Test == (4/8)" :spec 0.0 (if (== 0.0 -1.0) 1 0))
+(FPCore () :name "Test >= (8/8)" :spec 1.0 (if (>= 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test == (5/8)" :spec 0.0 (if (== 1.0 -1.0) 1 0))
+(FPCore () :name "Test == (1/9)" :spec 0.0 (if (== 1.0 0.0) 1 0))
 
-(FPCore () :name "Test == (6/8)" :spec 0.0 (if (== -1.0 1.0) 1 0))
+(FPCore () :name "Test == (2/9)" :spec 0.0 (if (== 0.0 1.0) 1 0))
 
-(FPCore () :name "Test == (7/8)" :spec 1.0 (if (== 0.0 0.0) 1 0))
+(FPCore () :name "Test == (3/9)" :spec 0.0 (if (== -1.0 0.0) 1 0))
 
-(FPCore () :name "Test == (8/8)" :spec 0.0 (if (== NAN NAN) 1 0))
+(FPCore () :name "Test == (4/9)" :spec 0.0 (if (== 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test != (1/8)" :spec 1.0 (if (!= 1.0 0.0) 1 0))
+(FPCore () :name "Test == (5/9)" :spec 0.0 (if (== 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test != (2/8)" :spec 1.0 (if (!= 0.0 1.0) 1 0))
+(FPCore () :name "Test == (6/9)" :spec 0.0 (if (== -1.0 1.0) 1 0))
 
-(FPCore () :name "Test != (3/8)" :spec 1.0 (if (!= -1.0 0.0) 1 0))
+(FPCore () :name "Test == (7/9)" :spec 1.0 (if (== 0.0 0.0) 1 0))
 
-(FPCore () :name "Test != (4/8)" :spec 1.0 (if (!= 0.0 -1.0) 1 0))
+(FPCore () :name "Test == (8/9)" :spec 0.0 (if (== NAN NAN) 1 0))
 
-(FPCore () :name "Test != (5/8)" :spec 1.0 (if (!= 1.0 -1.0) 1 0))
+(FPCore () :name "Test == (9/9)" :spec 1.0 (if (== 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test != (6/8)" :spec 1.0 (if (!= -1.0 1.0) 1 0))
+(FPCore () :name "Test != (1/9)" :spec 1.0 (if (!= 1.0 0.0) 1 0))
 
-(FPCore () :name "Test != (7/8)" :spec 0.0 (if (!= 0.0 0.0) 1 0))
+(FPCore () :name "Test != (2/9)" :spec 1.0 (if (!= 0.0 1.0) 1 0))
 
-(FPCore () :name "Test != (8/8)" :spec 1.0 (if (!= NAN NAN) 1 0))
+(FPCore () :name "Test != (3/9)" :spec 1.0 (if (!= -1.0 0.0) 1 0))
+
+(FPCore () :name "Test != (4/9)" :spec 1.0 (if (!= 0.0 -1.0) 1 0))
+
+(FPCore () :name "Test != (5/9)" :spec 1.0 (if (!= 1.0 -1.0) 1 0))
+
+(FPCore () :name "Test != (6/9)" :spec 1.0 (if (!= -1.0 1.0) 1 0))
+
+(FPCore () :name "Test != (7/9)" :spec 0.0 (if (!= 0.0 0.0) 1 0))
+
+(FPCore () :name "Test != (8/9)" :spec 1.0 (if (!= NAN NAN) 1 0))
+
+(FPCore () :name "Test != (9/9)" :spec 1.0 (if (== 0.0 0.0 0.0) 1 0))
 
 (FPCore () :name "Test and (1/4)" :spec 1.0 (if (and TRUE TRUE) 1 0))
 

--- a/tests/sanity/bool-ops.fpcore
+++ b/tests/sanity/bool-ops.fpcore
@@ -54,33 +54,37 @@
 
 (FPCore () :name "Test >= (7/7)" :spec 1.0 (if (>= 0.0 0.0) 1 0))
 
-(FPCore () :name "Test == (1/7)" :spec 0.0 (if (== 1.0 0.0) 1 0))
+(FPCore () :name "Test == (1/8)" :spec 0.0 (if (== 1.0 0.0) 1 0))
 
-(FPCore () :name "Test == (2/7)" :spec 0.0 (if (== 0.0 1.0) 1 0))
+(FPCore () :name "Test == (2/8)" :spec 0.0 (if (== 0.0 1.0) 1 0))
 
-(FPCore () :name "Test == (3/7)" :spec 0.0 (if (== -1.0 0.0) 1 0))
+(FPCore () :name "Test == (3/8)" :spec 0.0 (if (== -1.0 0.0) 1 0))
 
-(FPCore () :name "Test == (4/7)" :spec 0.0 (if (== 0.0 -1.0) 1 0))
+(FPCore () :name "Test == (4/8)" :spec 0.0 (if (== 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test == (5/7)" :spec 0.0 (if (== 1.0 -1.0) 1 0))
+(FPCore () :name "Test == (5/8)" :spec 0.0 (if (== 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test == (6/7)" :spec 0.0 (if (== -1.0 1.0) 1 0))
+(FPCore () :name "Test == (6/8)" :spec 0.0 (if (== -1.0 1.0) 1 0))
 
-(FPCore () :name "Test == (7/7)" :spec 1.0 (if (== 0.0 0.0) 1 0))
+(FPCore () :name "Test == (7/8)" :spec 1.0 (if (== 0.0 0.0) 1 0))
 
-(FPCore () :name "Test != (1/7)" :spec 1.0 (if (!= 1.0 0.0) 1 0))
+(FPCore () :name "Test == (8/8)" :spec 0.0 (if (== NAN NAN) 1 0))
 
-(FPCore () :name "Test != (2/7)" :spec 1.0 (if (!= 0.0 1.0) 1 0))
+(FPCore () :name "Test != (1/8)" :spec 1.0 (if (!= 1.0 0.0) 1 0))
 
-(FPCore () :name "Test != (3/7)" :spec 1.0 (if (!= -1.0 0.0) 1 0))
+(FPCore () :name "Test != (2/8)" :spec 1.0 (if (!= 0.0 1.0) 1 0))
 
-(FPCore () :name "Test != (4/7)" :spec 1.0 (if (!= 0.0 -1.0) 1 0))
+(FPCore () :name "Test != (3/8)" :spec 1.0 (if (!= -1.0 0.0) 1 0))
 
-(FPCore () :name "Test != (5/7)" :spec 1.0 (if (!= 1.0 -1.0) 1 0))
+(FPCore () :name "Test != (4/8)" :spec 1.0 (if (!= 0.0 -1.0) 1 0))
 
-(FPCore () :name "Test != (6/7)" :spec 1.0 (if (!= -1.0 1.0) 1 0))
+(FPCore () :name "Test != (5/8)" :spec 1.0 (if (!= 1.0 -1.0) 1 0))
 
-(FPCore () :name "Test != (7/7)" :spec 0.0 (if (!= 0.0 0.0) 1 0))
+(FPCore () :name "Test != (6/8)" :spec 1.0 (if (!= -1.0 1.0) 1 0))
+
+(FPCore () :name "Test != (7/8)" :spec 0.0 (if (!= 0.0 0.0) 1 0))
+
+(FPCore () :name "Test != (8/8)" :spec 1.0 (if (!= NAN NAN) 1 0))
 
 (FPCore () :name "Test and (1/4)" :spec 1.0 (if (and TRUE TRUE) 1 0))
 

--- a/tests/sanity/bool-ops.fpcore
+++ b/tests/sanity/bool-ops.fpcore
@@ -98,13 +98,17 @@
 
 (FPCore () :name "Test != (9/9)" :spec 1.0 (if (== 0.0 0.0 0.0) 1 0))
 
-(FPCore () :name "Test and (1/4)" :spec 1.0 (if (and TRUE TRUE) 1 0))
+(FPCore () :name "Test and (1/6)" :spec 1.0 (if (and TRUE TRUE) 1 0))
 
-(FPCore () :name "Test and (2/4)" :spec 0.0 (if (and TRUE FALSE) 1 0))
+(FPCore () :name "Test and (2/6)" :spec 0.0 (if (and TRUE FALSE) 1 0))
 
-(FPCore () :name "Test and (3/4)" :spec 0.0 (if (and FALSE TRUE) 1 0))
+(FPCore () :name "Test and (3/6)" :spec 0.0 (if (and FALSE TRUE) 1 0))
 
-(FPCore () :name "Test and (4/4)" :spec 0.0 (if (and FALSE FALSE) 1 0))
+(FPCore () :name "Test and (4/6)" :spec 0.0 (if (and FALSE FALSE) 1 0))
+
+(FPCore () :name "Test and (5/6)" :spec 1.0 (if (and TRUE TRUE TRUE) 1 0))
+
+(FPCore () :name "Test and (6/6)" :spec 0.0 (if (and TRUE TRUE FALSE) 1 0))
 
 (FPCore () :name "Test or (1/4)" :spec 1.0 (if (or TRUE TRUE) 1 0))
 
@@ -113,6 +117,10 @@
 (FPCore () :name "Test or (3/4)" :spec 1.0 (if (or FALSE TRUE) 1 0))
 
 (FPCore () :name "Test or (4/4)" :spec 0.0 (if (or FALSE FALSE) 1 0))
+
+(FPCore () :name "Test or (5/6)" :spec 0.0 (if (or FALSE FALSE FALSE) 1 0))
+
+(FPCore () :name "Test or (6/6)" :spec 1.0 (if (or FALSE FALSE TRUE) 1 0))
 
 (FPCore () :name "Test not (1/2)" :spec 0.0 (if (not TRUE) 1 0))
 


### PR DESCRIPTION
This PR adds missing boolean operator (sanity) tests and fixes the compilers that fail these new tests.
- `NaN` != `NaN`
- N-ary comparators, e.g. `(> x y z)` (3-ary is good enough)
- N-ary logical connectives, e.g. `(and x y z)` (3-ary is good enough)