### PR TITLE
Fix #116 by specifying input to Newton-Raphson

### DIFF
--- a/benchmarks/salsa.fpcore
+++ b/benchmarks/salsa.fpcore
@@ -207,7 +207,7 @@ Inputs: Initial guess `x0`"
                  [ff (+ (- (+ (- (* (* 5.0 x) (* (* x x) x)) (* (* 40.0 x) (* x x))) (* (* 120.0 x) x)) (* 160.0 x)) 80.0)])
              (- x (/ f ff)))]
       [e 1.0 (fabs (- x x_n))]
-      [x 0.0 x_n]
+      [x x0 x_n]
       [i 0.0 (+ i 1.0)])
      x))) ;; `i`, `x_n`, and `e` are also outputs but are skipped for now
 


### PR DESCRIPTION
This PR fixes #116 by specifying `x0` as an input to the Newton-Raphson benchmark.

This is tricky change because it changes the semantics of this benchmark if non-default inputs are used. Alternatively, I'm open to a change where we remove the input entirely, so that this benchmark just specifies a loop. This better matches the [original](https://github.com/FPBench/FPBench/blob/b054f2cc87fa9acfe985c84bbbaff2211bf7d650/originals/loop-tests/Newton-Raphson's%20Method) version of this benchmark.