### PR TITLE
Add Rust compiler support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,41 @@ jobs:
       - name: "Go test"
         run: make go-test
 
+  rust: # Rust language
+    name: "Rust Tests"
+    runs-on: ubuntu-latest
+    needs: [ 'unit' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Install Racket"
+        uses: Bogdanp/setup-racket@v1.5
+        with:
+          architecture: 'x64'
+          distribution: 'full'
+          variant: 'CS'
+          version: '8.2'
+
+      - name: "Install Rust"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: "Install Packages"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libmpfr6 libmpfr-dev
+
+      - name: "Install as Racket package"
+        run: raco pkg install --auto
+
+      - name: "Rust sanity"
+        run: make rust-sanity
+
+      - name: "Rust test"
+        run: make rust-test
+
   js:    # JavaScript langugae
     name: "JavaScript Tests"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ else
 endif
 
 rust-sanity:
-ifneq (, $(shell which cargo))
+ifneq (, $(shell which rustc))
 	cat tests/sanity/*.fpcore | racket infra/test-core2rust.rkt --repeat 1
 else
-	$(warning skipping Rust sanity tests; unable to find cargo)
+	$(warning skipping Rust sanity tests; unable to find Rust compiler)
 endif
 
 scala-sanity:
@@ -207,8 +207,8 @@ else
 endif
 
 rust-test:
-ifneq (, $(shell which cargo))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2rust.rkt -s --error 150
+ifneq (, $(shell which rustc))
+	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2rust.rkt -s --error 3
 else
 	$(warning skipping Rust tests; unable to find Rust compiler)
 endif

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,13 @@ else
 	$(warning skipping Go sanity tests; unable to find go)
 endif
 
+rust-sanity:
+ifneq (, $(shell which cargo))
+	cat tests/sanity/*.fpcore | racket infra/test-core2rust.rkt --repeat 1
+else
+	$(warning skipping Rust sanity tests; unable to find cargo)
+endif
+
 scala-sanity:
 ifneq (, $(shell which daisy))
 	cp -r $(DAISY_BASE)/library .
@@ -128,7 +135,8 @@ endif
 
 sanity: c-sanity java-sanity js-sanity go-sanity smtlib2-sanity sollya-sanity \
 		wls-sanity cml-sanity fptaylor-sanity scala-sanity ocaml-sanity \
-		python-sanity fortran-sanity matlab-sanity haskell-sanity julia-sanity
+		python-sanity fortran-sanity matlab-sanity haskell-sanity julia-sanity \
+		rust-sanity
 
 raco-test:
 	raco test .
@@ -196,6 +204,13 @@ ifneq (, $(shell which go))
 	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2go.rkt -s --error 150
 else
 	$(warning skipping Go tests; unable to find Go compiler)
+endif
+
+rust-test:
+ifneq (, $(shell which cargo))
+	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2rust.rkt -s --error 150
+else
+	$(warning skipping Rust tests; unable to find Rust compiler)
 endif
 
 scala-test:
@@ -299,8 +314,8 @@ tools-test: export-test transform-test toolserver-test evaluate-test tensor-test
 
 test: c-test java-test js-test go-test smtlib2-test sollya-test wls-test \
 	  cml-test fptaylor-test daisy-test ocaml-test python-test matlab-test \
-	  haskell-test export-test transform-test toolserver-test evaluate-test \
-	  raco-test
+	  haskell-test rust-test export-test transform-test toolserver-test \
+	  evaluate-test raco-test
 
 clean:
 	$(RM) -r library tmp log *.zo *.dep

--- a/export.rkt
+++ b/export.rkt
@@ -20,6 +20,7 @@
          "src/core2matlab.rkt"
          "src/core2ocaml.rkt"
          "src/core2python.rkt"
+         "src/core2rust.rkt"
          "src/core2scala.rkt"
          "src/core2smtlib2.rkt"
          "src/core2sollya.rkt"

--- a/infra/test-core2rust.rkt
+++ b/infra/test-core2rust.rkt
@@ -1,0 +1,57 @@
+#lang racket
+
+(require generic-flonum)
+(require "test-common.rkt" "../src/core2rust.rkt")
+
+(define (compile->rust prog ctx type test-file)
+  (define bit-length (match type ['binary64 "64"] ['binary32 "32"]))
+  (call-with-output-file test-file #:exists 'replace
+    (λ (p)
+      (define N (if (list? (second prog)) (length (second prog)) (length (third prog))))
+      (fprintf p (rust-header ""))
+      (fprintf p "#[allow(dead_code)]\nfn strtox(arg: String) -> f~a {\n    use std::str::FromStr;\n    f~a::from_str(&arg).unwrap_or_default()\n}\n\n" bit-length bit-length)
+      (fprintf p "~a\n" (core->rust prog "f"))
+      (fprintf p "fn main() {\n")
+      (fprintf p "    print!(\"{:.20E}\", f(~a));\n}\n"
+          (string-join (map (curry format "strtox(std::env::args().nth(~a).unwrap())") (map add1 (range N))) ", "))))
+  (define bin-file (string-replace test-file ".rs" "-rust.bin"))
+    (system (format "rustc -o ~a ~a" bin-file test-file))
+    bin-file)
+
+(define (run<-rust exec-name ctx type number)
+  (define in
+    (for/list ([val (dict-values ctx)])
+      (match (value->string val)
+       ["+nan.0" "NaN"]
+       ["+inf.0" "inf"]
+       ["-inf.0" "-inf"]
+       [x x])))
+  (define out
+    (with-output-to-string
+     (λ ()
+      (system (string-join (cons exec-name in) " ")))))
+  (define out*
+    (match out
+      ["NaN" "+nan.0"]
+      ["inf" "+inf.0"]
+      ["-inf" "-inf.0"]
+      [x x]))
+  (cons (->value out* type) out*))
+
+(define (rust-equality a b ulps type ignore?)
+  (cond
+    [(equal? a 'timeout) true]
+    [else (<= (abs (gfls-between a b)) ulps)]))
+
+(define (rust-format-args var val type)
+  (format "~a = ~a" var val))
+
+(define (rust-format-output result)
+  (format "~a" result))
+
+(define rust-tester (tester "rust" compile->rust run<-rust rust-equality rust-format-args rust-format-output (const #t) rust-supported #f))
+
+; Command line
+(module+ main (parameterize ([*tester* rust-tester])
+  (let ([state (test-core (current-command-line-arguments) (current-input-port) "stdin" "/tmp/test.rs")])
+    (exit state))))

--- a/src/core2rust.rkt
+++ b/src/core2rust.rkt
@@ -1,0 +1,110 @@
+#lang racket
+
+(require "imperative.rkt")
+
+(provide rust-header core->rust rust-supported)
+
+(define rust-header (lambda (_) "#![allow(non_snake_case, unused_mut, unused_parens)]\n\n"))
+
+(define rust-supported
+  (supported-list
+    (invert-op-proc (curry set-member? '(tgamma lgamma fdim erf erfc remainder)))
+    (invert-const-proc (curry set-member? '(SQRT1_2)))
+    (curry equal? 'binary64)
+    (curry equal? 'nearestEven)))
+
+(define rust-reserved   ; Language-specific reserved names (avoid name collisions)
+  '(as break const continue crate else enum extern false fn for if impl in let loop match
+  mod move mut pub ref return self Self static struct super trait true type unsafe use
+  where while async await dyn abstract become box do final macro override priv typeof
+  unsized virtual yield try))
+
+(define/match (type->rust type)
+  [('binary64) "f64"]
+  [('binary32) "f32"]
+  [('boolean) "bool"])
+
+(define/match (rust-type->suffix type)
+  [("f64") "f64"]
+  [("f32") "f32"]
+  [("boolean") ""])
+
+(define (operator->rust op args ctx)
+  (define args* (string-join args ", "))
+  (match op
+    ['/     (format "(~a / ~a)" (first args) (second args))]
+    ['isinf (format "f64::is_infinite(~a)" args*)]
+    ['isnan (format "f64::is_nan(~a)" args*)]
+    ['log1p (format "f64::ln_1p(~a)" args*)]
+    ['fma (format "f64::mul_add(~a)" args*)]
+    ['fmax (format "f64::max(~a)" args*)]
+    ['fmin (format "f64::min(~a)" args*)]
+    ['nearbyint (format "f64::round(~a)" args*)]
+    ['fabs (format "f64::abs(~a)" args*)]
+    ['fmod (format "(~a % ~a)" (first args) (second args))]
+    ['expm1 (format "f64::exp_m1(~a)" args*)]
+    ['signbit (format "f64::is_sign_negative(~a)" args*)]
+    ['pow (format "f64::powf(~a)" args*)]
+    [(or 'exp 'exp2 'log 'log10 'log2 'sqrt 'cbrt 'hypot
+         'sin 'cos 'tan 'asin 'acos 'atan 'atan2 'sinh 'cosh 'tanh
+         'asinh 'acosh 'atanh 'ceil 'floor
+         'copysign 'trunc 'round)
+     (format "f64::~a(~a)" (~a op) args*)]))
+
+(define (constant->rust x ctx)
+  (define type (type->rust (ctx-lookup-prop ctx ':precision)))
+  (match x
+    ['E "std::f64::consts::E"]
+    ['LOG2E "std::f64::consts::LOG2_E"]
+    ['LOG10E "std::f64::consts::LOG10_E"]
+    ['LN2 "std::f64::consts::LN_2"]
+    ['LN10 "std::f64::consts::LN_10"]
+    ['PI "std::f64::consts::PI"]
+    ['PI_2 "std::f64::consts::FRAC_PI_2"]
+    ['PI_4 "std::f64::consts::FRAC_PI_4"]
+    ['M_1_PI "std::f64::consts::FRAC_1_PI"]
+    ['M_2_PI "std::f64::consts::FRAC_2_PI"]
+    ['M_2_SQRTPI "std::f64::consts::FRAC_2_SQRT_PI"]
+    ['SQRT2 "std::f64::consts::SQRT_2"]
+    ['MAXFLOAT "f64::MAX"]
+    ['INFINITY "f64::INFINITY"]
+    ['NAN "f64::NAN"]
+    ['TRUE "true"]
+    ['FALSE "false"]
+    [(? hex?) (~a x)]
+    [(? number?) (format "~a~a" (real->double-flonum x) (rust-type->suffix type))]
+    [(? symbol?) (~a x)]))
+
+(define declaration->rust
+  (case-lambda
+   [(var ctx)
+    (define type (type->rust (ctx-lookup-prop ctx ':precision)))
+    (format "let mut ~a: ~a;" var type)]
+   [(var val ctx)
+    (define type (type->rust (ctx-lookup-prop ctx ':precision)))
+    (format "let mut ~a: ~a = ~a;" var type val)]))
+
+(define (params->rust args arg-ctxs)
+  (string-join
+    (for/list ([arg (in-list args)] [ctx (in-list arg-ctxs)])
+      (let ([type (type->rust (ctx-lookup-prop ctx ':precision))])
+        (format "~a: ~a" arg type)))
+    ", "))
+
+(define (program->rust name args arg-ctxs body return ctx vars)
+  (define type (type->rust (ctx-lookup-prop ctx ':precision)))
+  (format "fn ~a(~a) -> ~a {\n~a\t~a\n}\n"
+          name (params->rust args arg-ctxs) type
+          body return))
+
+(define core->rust
+  (make-imperative-compiler "rust"
+    #:operator operator->rust
+    #:constant constant->rust
+    #:type type->rust
+    #:declare declaration->rust
+    #:program program->rust
+    #:flags '(no-parens-around-condition spaces-for-tabs)
+    #:reserved rust-reserved))
+
+(define-compiler '("rs") rust-header core->rust (const "") rust-supported)

--- a/src/core2rust.rkt
+++ b/src/core2rust.rkt
@@ -33,8 +33,11 @@
   (define args* (string-join args ", "))
   (match op
     ['/     (format "(~a / ~a)" (first args) (second args))]
+    ['isfinite (format "f64::is_finite(~a)" args*)]
     ['isinf (format "f64::is_infinite(~a)" args*)]
     ['isnan (format "f64::is_nan(~a)" args*)]
+    ['isnormal (format "f64::is_normal(~a)" args*)]
+    ['log (format "f64::ln(~a)" args*)]
     ['log1p (format "f64::ln_1p(~a)" args*)]
     ['fma (format "f64::mul_add(~a)" args*)]
     ['fmax (format "f64::max(~a)" args*)]
@@ -45,7 +48,7 @@
     ['expm1 (format "f64::exp_m1(~a)" args*)]
     ['signbit (format "f64::is_sign_negative(~a)" args*)]
     ['pow (format "f64::powf(~a)" args*)]
-    [(or 'exp 'exp2 'log 'log10 'log2 'sqrt 'cbrt 'hypot
+    [(or 'exp 'exp2 'log10 'log2 'sqrt 'cbrt 'hypot
          'sin 'cos 'tan 'asin 'acos 'atan 'atan2 'sinh 'cosh 'tanh
          'asinh 'acosh 'atanh 'ceil 'floor
          'copysign 'trunc 'round)
@@ -71,7 +74,7 @@
     ['NAN "f64::NAN"]
     ['TRUE "true"]
     ['FALSE "false"]
-    [(? hex?) (~a x)]
+    [(? hex?) (format "~a~a" (real->double-flonum (hex->racket x)) (rust-type->suffix type))]
     [(? number?) (format "~a~a" (real->double-flonum x) (rust-type->suffix type))]
     [(? symbol?) (~a x)]))
 

--- a/src/core2rust.rkt
+++ b/src/core2rust.rkt
@@ -4,7 +4,7 @@
 
 (provide rust-header core->rust rust-supported)
 
-(define rust-header (lambda (_) "#![allow(non_snake_case, unused_mut, unused_parens)]\n\n"))
+(define rust-header (lambda (_) "#![allow(unused_mut, unused_parens)]\n\n"))
 
 (define rust-supported
   (supported-list
@@ -18,6 +18,14 @@
   mod move mut pub ref return self Self static struct super trait true type unsafe use
   where while async await dyn abstract become box do final macro override priv typeof
   unsized virtual yield try))
+
+(define (rust-fix-name name)
+  (string-join
+   (for/list ([char (~a name)])
+     (if (regexp-match #rx"[a-zA-Z0-9_]" (string char))
+         (string (char-downcase char))
+         (format "_~a" (char->integer char))))
+   ""))
 
 (define/match (type->rust type)
   [('binary64) "f64"]
@@ -107,6 +115,7 @@
     #:type type->rust
     #:declare declaration->rust
     #:program program->rust
+    #:fix-name rust-fix-name
     #:flags '(no-parens-around-condition spaces-for-tabs)
     #:reserved rust-reserved))
 

--- a/src/imperative.rkt
+++ b/src/imperative.rkt
@@ -1,6 +1,6 @@
 ;
 ;   Common compiler for all imperative languages
-;     C, JS, Go, Sollya, Scala, Fortran
+;     C, JS, Go, Rust, Sollya, Scala, Fortran
 ;     FPTaylor, MATLAB
 ;
 
@@ -37,7 +37,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;; flags ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define valid-flags
-  '(no-parens-around-condition        ; removes parenthesis from 'if' and 'while' conditions (Go, Python)
+  '(no-parens-around-condition        ; removes parenthesis from 'if' and 'while' conditions (Go, Python, Rust)
     for-instead-of-while              ; changes 'while' to 'for' (Go)
     never-declare                     ; declarations are assignments (Sollya, FPTaylor, Fortran)
     semicolon-after-enclosing-brace   ; end 'if' or 'while' blocks with "};" (Sollya)
@@ -48,7 +48,7 @@
     use-elif                          ; use 'elif' instead of 'else if' (Python)
     use-elseif                        ; use 'elseif' instead of 'else if' (MATLAB, Julia)
     boolean-ops-use-name              ; boolean operators use alphabetic name rather than symbol (Python)
-    spaces-for-tabs                   ; replace tabs with 4 spaces (Fortran)
+    spaces-for-tabs                   ; replace tabs with 4 spaces (Fortran, Rust)
     do-while                          ; changes 'while' to 'do while' (Fortran)
     end-block-with-name               ; blocks enclosed by "<x> ... end <x>, implicitly no braces" (Fortran)
     end-block-with-end                ; blocks ended by "end", implictly no braces" (MATLAB, Julia)


### PR DESCRIPTION
This PR adds supports for exporting to Rust, and corresponding tests.

Things to note:
- Rust supports both `f32` and `f64` for computations as well as storage. However, this PR only adds `binary64`/`f64` support.
- [Rust supports `fdim` as `{f32, f64}::abs_sub` except it is deprecated](https://doc.rust-lang.org/std/primitive.f64.html#method.abs_sub) so I didn't add it.
- I added some directives to ignore many compiler warnings, with the exception of unused variables/assignments (in my opinion, they represent FPCore programming errors). Let me know if those warnings should be silenced too.
- A subset of `asinh`/`acosh` tests (really large inputs) fail due to precision issues with Rust's implementation of them. The failures are apparently "suppressed"
- I was introduced to the codebase a few hours ago, so I'm far from understanding it and this PR should be scrutinized for errors.
- If you are wondering why you don't see a corresponding email or mailing list post, that's because I didn't send one (at least not yet). Feel free to close this PR for any reason, including lack of prior coordination.