### PR TITLE
Disable tensor tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -591,7 +591,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.8
+          version: '1.8'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -621,7 +621,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.8
+          version: '1.8'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -646,7 +646,12 @@ jobs:
       - name: "Install Packages"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmpfr6 libmpfr-dev julia
+          sudo apt-get install -y libmpfr6 libmpfr-dev
+
+      - name: "Install Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.8'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -671,7 +676,12 @@ jobs:
       - name: "Install Packages"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmpfr6 libmpfr-dev julia
+          sudo apt-get install -y libmpfr6 libmpfr-dev
+      
+      - name: "Install Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.8'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -591,7 +591,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: ${JULIA_VERSION}
+          version: 1.8
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -621,7 +621,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: ${JULIA_VERSION}
+          version: 1.8
 
       - name: "Install as Racket package"
         run: raco pkg install --auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ env:
   CAKEML_BIN: '../cache/cakeml'
   DAISY_VERSION: 'b483303f3914106173902669855d371ff73bf568'
   DAISY_BASE: '../cache/daisy'
+  JULIA_VERSION: '1.8'
   
 jobs:
   unit:   # package setup, Racket unit testing
@@ -585,7 +586,12 @@ jobs:
       - name: "Install Packages"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmpfr6 libmpfr-dev julia
+          sudo apt-get install -y libmpfr6 libmpfr-dev
+
+      - name: "Install Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${JULIA_VERSION}
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -610,7 +616,12 @@ jobs:
       - name: "Install Packages"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmpfr6 libmpfr-dev julia
+          sudo apt-get install -y libmpfr6 libmpfr-dev
+      
+      - name: "Install Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${JULIA_VERSION}
 
       - name: "Install as Racket package"
         run: raco pkg install --auto

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SANITY = tests/sanity/*.fpcore
+TESTS = benchmarks/*.fpcore tests/*.fpcore tests/tensor/*.fpcore
 FILTER = racket infra/filter.rkt
 
 ### Install / Compile
@@ -13,21 +15,21 @@ testsetup:
 
 c-sanity:
 ifneq (, $(shell which $(CC)))
-	cat tests/sanity/*.fpcore | racket infra/test-core2c.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2c.rkt --repeat 1
 else
 	$(warning skipping C sanity tests; unable to find C compiler $(CC))
 endif
 
 java-sanity:
 ifneq (, $(shell which java))
-	cat tests/sanity/*.fpcore | racket infra/test-core2java.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2java.rkt --repeat 1
 else
 	$(warning skipping Java sanity tests; unable to find Java compiler)
 endif
 
 fptaylor-sanity:
 ifneq (, $(shell which fptaylor))
-	cat tests/sanity/*.fpcore | racket infra/test-core2fptaylor.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2fptaylor.rkt --repeat 1
 	$(RM) -r log tmp
 else
 	$(warning skipping fptaylor sanity tests; unable to find fptaylor)
@@ -35,49 +37,49 @@ endif
 
 js-sanity:
 ifneq (, $(shell which node))
-	cat tests/sanity/*.fpcore | racket infra/test-core2js.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2js.rkt --repeat 1
 else
 	$(warning skipping javascript sanity tests; unable to find node)
 endif
 
 smtlib2-sanity:
 ifneq (, $(shell which z3))
-	cat tests/sanity/*.fpcore | racket infra/test-core2smtlib2.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2smtlib2.rkt --repeat 1
 else
 	$(warning skipping smtlib2 sanity tests; unable to find z3)
 endif
 
 sollya-sanity:
 ifneq (, $(shell which sollya))
-	cat tests/sanity/*.fpcore | racket infra/test-core2sollya.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2sollya.rkt --repeat 1
 else
 	$(warning skipping sollya sanity tests; unable to sollya interpreter)
 endif
 
 cakeml-sanity:
 ifneq (, $(shell which cake))
-	cat tests/sanity/*.fpcore | racket infra/test-core2cakeml.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2cakeml.rkt --repeat 1
 else
 	$(warning skipping CakeML sanity tests; unable to find CakeML compiler)
 endif
 
 wls-sanity:
 ifneq (, $(shell which wolframscript))
-	cat tests/sanity/*.fpcore | racket infra/test-core2wls.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2wls.rkt --repeat 1
 else
 	$(warning skipping wolframscript sanity tests; unable to find wolframscript interpreter)
 endif
 
 go-sanity:
 ifneq (, $(shell which go))
-	cat tests/sanity/*.fpcore | racket infra/test-core2go.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2go.rkt --repeat 1
 else
 	$(warning skipping Go sanity tests; unable to find go)
 endif
 
 rust-sanity:
 ifneq (, $(shell which rustc))
-	cat tests/sanity/*.fpcore | racket infra/test-core2rust.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2rust.rkt --repeat 1
 else
 	$(warning skipping Rust sanity tests; unable to find Rust compiler)
 endif
@@ -85,7 +87,7 @@ endif
 scala-sanity:
 ifneq (, $(shell which daisy))
 	cp -r $(DAISY_BASE)/library .
-	cat tests/sanity/*.fpcore | racket infra/test-core2scala.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2scala.rkt --repeat 1
 	rm -r library
 else
 	$(warning skipping Scala sanity tests; unable to find Scala compiler)
@@ -93,42 +95,42 @@ endif
 
 ocaml-sanity:
 ifneq (, $(shell which ocamlopt))
-	cat tests/sanity/*.fpcore | racket infra/test-core2ocaml.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2ocaml.rkt --repeat 1
 else
 	$(warning skipping OCaml sanity tests; unable to find OCaml compiler)
 endif
 
 python-sanity:
 ifneq (, $(shell which python3))
-	cat tests/sanity/*.fpcore | racket infra/test-core2python.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2python.rkt --repeat 1
 else
 	$(warning skipping Python sanity tests; unable to find Python interpreter)
 endif
 
 fortran-sanity:
 ifneq (, $(shell which $(CC)))
-	cat tests/sanity/*.fpcore | racket infra/test-core2fortran03.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2fortran03.rkt --repeat 1
 else
 	$(warning skipping Fortran sanity tests; unable to find Fortran compiler)
 endif
 
 matlab-sanity:
 ifneq (, $(shell which matlab))
-	cat tests/sanity/*.fpcore | racket infra/test-core2matlab.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2matlab.rkt --repeat 1
 else
 	$(warning skipping MATLAB sanity tests; unable to find MATLAB tool)
 endif
 
 haskell-sanity:
 ifneq (, $(shell which ghc))
-	cat tests/sanity/*.fpcore | racket infra/test-core2haskell.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2haskell.rkt --repeat 1
 else
 	$(warning skipping Haskell sanity tests; unable to find Haskell compiler)
 endif
 
 julia-sanity:
 ifneq (, $(shell which julia))
-	cat tests/sanity/*.fpcore | racket infra/test-core2julia.rkt --repeat 1
+	cat $(SANITY) | racket infra/test-core2julia.rkt --repeat 1
 else
 	$(warning skipping Julia sanity tests; unable to find Julia interpreter)
 endif
@@ -143,21 +145,21 @@ raco-test:
 
 c-test:
 ifneq (, $(shell which $(CC)))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2c.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2c.rkt --error 3
 else
 	$(warning skipping C tests; unable to find C compiler $(CC))
 endif
 
 java-test:
 ifneq (, $(shell which java))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2java.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2java.rkt --error 3
 else
 	$(warning skipping Java tests; unable to find Java compiler)
 endif
 
 fptaylor-test:
 ifneq (, $(shell which fptaylor))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2fptaylor.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2fptaylor.rkt --error 3
 	$(RM) -r log tmp
 else
 	$(warning skipping fptaylor tests; unable to find fptaylor)
@@ -165,35 +167,35 @@ endif
 
 js-test:
 ifneq (, $(shell which node))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2js.rkt --error 150
+	cat $(TESTS) | racket infra/test-core2js.rkt --error 150
 else
 	$(warning skipping javascript tests; unable to find node)
 endif
 
 smtlib2-test:
 ifneq (, $(shell which z3))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2smtlib2.rkt
+	cat $(TESTS) | racket infra/test-core2smtlib2.rkt
 else
 	$(warning skipping smtlib2 tests; unable to find z3)
 endif
 
 sollya-test:
 ifneq (, $(shell which sollya))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2sollya.rkt
+	cat $(TESTS) | racket infra/test-core2sollya.rkt
 else
 	$(warning skipping sollya tests; unable to find sollya interpreter)
 endif
 
 cakeml-test:
 ifneq (, $(shell which cake))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2cakeml.rkt
+	cat $(TESTS) | racket infra/test-core2cakeml.rkt
 else
 	$(warning skipping CakeML tests; unable to find CakeML compiler)
 endif
 
 wls-test:
 ifneq (, $(shell which wolframscript))
-	cat benchmarks/*.fpcore tests/*.fpcore  | racket infra/test-core2wls.rkt -s --error 150
+	cat $(TESTS)  | racket infra/test-core2wls.rkt -s --error 150
 
 else
 	$(warning skipping wolframscript tests; unable to find wolframscript interpreter)
@@ -201,14 +203,14 @@ endif
 
 go-test:
 ifneq (, $(shell which go))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2go.rkt -s --error 150
+	cat $(TESTS) | racket infra/test-core2go.rkt -s --error 150
 else
 	$(warning skipping Go tests; unable to find Go compiler)
 endif
 
 rust-test:
 ifneq (, $(shell which rustc))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2rust.rkt -s --error 3
+	cat $(TESTS) | racket infra/test-core2rust.rkt -s --error 3
 else
 	$(warning skipping Rust tests; unable to find Rust compiler)
 endif
@@ -216,7 +218,7 @@ endif
 scala-test:
 ifneq (, $(shell which daisy))
 	cp -r $(DAISY_BASE)/library .
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2scala.rkt
+	cat $(TESTS) | racket infra/test-core2scala.rkt
 	rm -r library
 else
 	$(warning skipping Scala tests; unable to find Scala compiler)
@@ -224,42 +226,42 @@ endif
 
 ocaml-test:
 ifneq (, $(shell which ocamlopt))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2ocaml.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2ocaml.rkt --error 3
 else
 	$(warning skipping OCaml tests; unable to find OCaml compiler)
 endif
 
 python-test:
 ifneq (, $(shell which python3))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2python.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2python.rkt --error 3
 else
 	$(warning skipping Python tests; unable to find Python interpreter)
 endif
 
 fortran-test:
 ifneq (, $(shell which $(CC)))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2fortran03.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2fortran03.rkt --error 3
 else
 	$(warning skipping Fortran tests; unable to find Fortran compiler)
 endif
 
 matlab-test:
 ifneq (, $(shell which matlab))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2matlab.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2matlab.rkt --error 3
 else
 	$(warning skipping MATLAB sanity tests; unable to find MATLAB tool)
 endif
 
 haskell-test:
 ifneq (, $(shell which ghc))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2haskell.rkt --error 3
+	cat $(TESTS) | racket infra/test-core2haskell.rkt --error 3
 else
 	$(warning skipping Haskell tests; unable to find Haskell compiler)
 endif
 
 julia-test:
 ifneq (, $(shell which julia))
-	cat benchmarks/*.fpcore tests/*.fpcore | racket infra/test-core2julia.rkt --error 20
+	cat $(TESTS) | racket infra/test-core2julia.rkt --error 20
 else
 	$(warning skipping Julia tests; unable to find Julia interpreter)
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SANITY = tests/sanity/*.fpcore
-TESTS = benchmarks/*.fpcore tests/*.fpcore tests/tensor/*.fpcore
+TESTS = benchmarks/*.fpcore tests/*.fpcore
 FILTER = racket infra/filter.rkt
 
 ### Install / Compile

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -12,7 +12,8 @@
     (invert-op-proc (curry set-member? '(array dim size ref for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary32 binary64 binary80 integer))
-    (invert-rnd-mode-proc (curry equal? 'nearestAway))))
+    (invert-rnd-mode-proc (curry equal? 'nearestAway))
+    #f))
 
 (define c-reserved  ; Language-specific reserved names (avoid name collisions)
   '(auto break case char const continue default

--- a/src/core2c.rkt
+++ b/src/core2c.rkt
@@ -9,7 +9,7 @@
 (define c-header (const "#include <fenv.h>\n#include <math.h>\n#include <stdint.h>\n#define TRUE 1\n#define FALSE 0\n\n"))
 (define c-supported 
   (supported-list
-    fpcore-ops
+    (invert-op-proc (curry set-member? '(array dim size ref for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary32 binary64 binary80 integer))
     (invert-rnd-mode-proc (curry equal? 'nearestAway))))

--- a/src/core2cakeml.rkt
+++ b/src/core2cakeml.rkt
@@ -12,7 +12,8 @@
                                   array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN))
     (curry equal? 'binary64)
-    (curry equal? 'nearestEven))) ; bool
+    (curry equal? 'nearestEven) ; bool
+    #f))
 
 (define cml-reserved    ; Language-specific reserved names (avoid name collisions)
   '(datatype fun else end if in let local

--- a/src/core2cakeml.rkt
+++ b/src/core2cakeml.rkt
@@ -7,7 +7,9 @@
 (define cml-supported
   (supported-list
     (disjoin (conjoin ieee754-ops (negate (curry equal? 'fma)))
-             (curry set-member? '(! cast if let let* while while* not and or digits))) 
+             (curry set-member? '(! cast if let let* while while*
+                                  not and or digits
+                                  array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN))
     (curry equal? 'binary64)
     (curry equal? 'nearestEven))) ; bool

--- a/src/core2fortran03.rkt
+++ b/src/core2fortran03.rkt
@@ -15,7 +15,8 @@
           array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE))
     (curry set-member? '(binary32 binary64 integer))
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define fortran-reserved    ; Language-specific reserved names (avoid name collisions)
   '(abstract allocatable allocate assign associate asynchronous backspace bind

--- a/src/core2fortran03.rkt
+++ b/src/core2fortran03.rkt
@@ -11,7 +11,8 @@
       (curry set-member?
         '(acosh asinh atanh cbrt ceil copysign erf erfc exp2 expm1 floor fma
           hypot isfinite isinf isnormal lgamma log1p log2 nearbyint remainder
-          signbit tgamma trunc)))
+          signbit tgamma trunc
+          array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE))
     (curry set-member? '(binary32 binary64 integer))
     (curry equal? 'nearestEven)))

--- a/src/core2fptaylor.rkt
+++ b/src/core2fptaylor.rkt
@@ -16,7 +16,8 @@
     (invert-const-proc (curry set-member? '(NAN INFINITY)))
     (curry set-member? '(binary16 binary32 binary64 binary128 real))
     ; Note: nearestEven and nearestAway behave identically in FPTaylor
-    ieee754-rounding-modes))
+    ieee754-rounding-modes
+    #f))
 
 ; Language-specific reserved names (avoid name collisions)
 (define fptaylor-reserved

--- a/src/core2fptaylor.rkt
+++ b/src/core2fptaylor.rkt
@@ -11,7 +11,8 @@
     (invert-op-proc 
       (curry set-member?
              '(atan2 cbrt ceil copysign erf erfc exp2 expm1 fdim floor fmod hypot if 
-              lgamma log10 log1p log2 nearbyint pow remainder round tgamma trunc while while*)))
+              lgamma log10 log1p log2 nearbyint pow remainder round tgamma trunc while while*
+              array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(NAN INFINITY)))
     (curry set-member? '(binary16 binary32 binary64 binary128 real))
     ; Note: nearestEven and nearestAway behave identically in FPTaylor

--- a/src/core2gappa.rkt
+++ b/src/core2gappa.rkt
@@ -5,7 +5,10 @@
 
 (define gappa-supported
   (supported-list 
-    (disjoin ieee754-ops (curry set-member? '(let not and or)))
+    (disjoin ieee754-ops
+             (curry set-member?
+                    '(let not and or array dim size ref
+                      for for* tensor tensor*)))
     (curry set-member? '(SQRT2 SQRT1_2 TRUE FALSE))
     (curry set-member? '(binary32 binary64 binary80 binary128))
     (curry equal? 'nearestEven)))

--- a/src/core2gappa.rkt
+++ b/src/core2gappa.rkt
@@ -11,7 +11,8 @@
                       for for* tensor tensor*)))
     (curry set-member? '(SQRT2 SQRT1_2 TRUE FALSE))
     (curry set-member? '(binary32 binary64 binary80 binary128))
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define (fix-name name)
   (string-join

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -25,7 +25,8 @@
               array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(M_1_PI M_2_PI M_2_SQRTPI SQRT1_2)))
     (curry equal? 'binary64)
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define go-reserved   ; Language-specific reserved names (avoid name collisions)
   '(break case chan const continue default defer else

--- a/src/core2go.rkt
+++ b/src/core2go.rkt
@@ -19,7 +19,10 @@
                    
 (define go-supported 
   (supported-list
-    (invert-op-proc (curry set-member? '(fma isnormal isfinite)))
+    (invert-op-proc
+      (curry set-member?
+            '(fma isnormal isfinite array dim size ref
+              array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(M_1_PI M_2_PI M_2_SQRTPI SQRT1_2)))
     (curry equal? 'binary64)
     (curry equal? 'nearestEven)))

--- a/src/core2haskell.rkt
+++ b/src/core2haskell.rkt
@@ -20,7 +20,8 @@
       (curry set-member?
         '(acosh asinh atanh cbrt ceil erf erfc exp2 fdim floor fma fmod
           hypot isnormal lgamma log2 log10 nearbyint remainder round
-          signbit tgamma trunc)))
+          signbit tgamma trunc
+          array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN PI E))
     (curry set-member? '(binary64 binary32))
     (curry equal? 'nearestEven)))

--- a/src/core2haskell.rkt
+++ b/src/core2haskell.rkt
@@ -24,7 +24,8 @@
           array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN PI E))
     (curry set-member? '(binary64 binary32))
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define haskell-reserved    ; Language-specific reserved names (avoid name collision)
   '(as case class data default deriving do else family forall foreign

--- a/src/core2java.rkt
+++ b/src/core2java.rkt
@@ -26,7 +26,8 @@
     (invert-op-proc
       (curry set-member?
         '(acosh asinh atanh erf erfc exp2 fdim fma fmod isnormal
-          lgamma log2 nearbyint round signbit tgamma trunc))) ; round is not C99 round
+          lgamma log2 nearbyint round signbit tgamma trunc
+          array dim size ref for for* tensor tensor*))) ; round is not C99 round
     (curry set-member? '(E PI INFINITY NAN TRUE FALSE MAXFLOAT))
     (curry equal? 'binary64)    ; binary32 only supported as storage format
     (curry equal? 'nearestEven)))

--- a/src/core2java.rkt
+++ b/src/core2java.rkt
@@ -30,7 +30,8 @@
           array dim size ref for for* tensor tensor*))) ; round is not C99 round
     (curry set-member? '(E PI INFINITY NAN TRUE FALSE MAXFLOAT))
     (curry equal? 'binary64)    ; binary32 only supported as storage format
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define java-reserved  ; Language-specific reserved names (avoid name collisions)
   '(abstract assert boolean break byte case catch char class

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -27,7 +27,8 @@
               array dim size ref for for* tensor tensor*)))
     fpcore-consts
     (curry equal? 'binary64)
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define js-reserved   ; Language-specific reserved names (avoid name collisions)
   '(abstract arguments await boolean break byte case catch char

--- a/src/core2js.rkt
+++ b/src/core2js.rkt
@@ -21,8 +21,10 @@
 (define js-supported 
   (supported-list
     (invert-op-proc 
-      (curry set-member? '(!= copysign exp2 erf erfc fma fmod isfinite isnormal   
-                             lgamma nearbyint remainder signbit tgamma)))
+      (curry set-member?
+            '(!= copysign exp2 erf erfc fma fmod isfinite isnormal   
+              lgamma nearbyint remainder signbit tgamma
+              array dim size ref for for* tensor tensor*)))
     fpcore-consts
     (curry equal? 'binary64)
     (curry equal? 'nearestEven)))

--- a/src/core2julia.rkt
+++ b/src/core2julia.rkt
@@ -13,7 +13,8 @@
       (curry set-member?
         '(MAXFLOAT)))
     (curry set-member? '(binary16 binary32 binary64))
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define julia-reserved      ; Language-specific reserved names (avoid name collisions)
   '(abstract baremodule begin break catch const continue do else elseif

--- a/src/core2julia.rkt
+++ b/src/core2julia.rkt
@@ -7,7 +7,8 @@
   (supported-list
     (invert-op-proc
       (curry set-member?
-        '(erf erfc fdim isnormal lgamma nearbyint remainder tgamma)))
+        '(erf erfc fdim isnormal lgamma nearbyint remainder tgamma
+          array dim size ref for for* tensor tensor*)))
     (invert-const-proc
       (curry set-member?
         '(MAXFLOAT)))

--- a/src/core2matlab.rkt
+++ b/src/core2matlab.rkt
@@ -9,7 +9,8 @@
     (invert-op-proc
       (curry set-member?
         '(cbrt exp2 expm1 fdim fma fmod isnormal log1p
-          nearbyint remainder signbit)))
+          nearbyint remainder signbit
+          array dim size ref for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary32 binary64))
     (curry equal? 'nearestEven)))

--- a/src/core2matlab.rkt
+++ b/src/core2matlab.rkt
@@ -13,7 +13,8 @@
           array dim size ref for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary32 binary64))
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define cpp-reserved
   '(catch class const_cast delete dynamic_cast explicit export friend

--- a/src/core2ocaml.rkt
+++ b/src/core2ocaml.rkt
@@ -9,7 +9,8 @@
     (invert-op-proc
       (curry set-member?
         '(acosh asinh atanh cbrt erf erfc exp2 fdim
-          lgamma log2 nearbyint remainder tgamma)))
+          lgamma log2 nearbyint remainder tgamma
+          array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN MAX_VALUE PI E))
     (curry equal? 'binary64)
     (curry equal? 'nearestEven)))

--- a/src/core2ocaml.rkt
+++ b/src/core2ocaml.rkt
@@ -13,7 +13,8 @@
           array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN MAX_VALUE PI E))
     (curry equal? 'binary64)
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define ocaml-reserved          ; Language-specific reserved names (avoid name collision)
   '(and as asssert asr begin class constraint do done down to else

--- a/src/core2python.rkt
+++ b/src/core2python.rkt
@@ -17,7 +17,9 @@
 (define python-supported
   (supported-list
     (invert-op-proc
-      (curry set-member? '(cbrt exp2 fdim fma isnormal nearbyint round signbit)))
+      (curry set-member?
+            '(cbrt exp2 fdim fma isnormal nearbyint round signbit
+              array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN PI E))
     (curry equal? 'binary64)
     (curry equal? 'nearestEven)))

--- a/src/core2python.rkt
+++ b/src/core2python.rkt
@@ -22,7 +22,8 @@
               array dim size ref for for* tensor tensor*)))
     (curry set-member? '(TRUE FALSE INFINITY NAN PI E))
     (curry equal? 'binary64)
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define python-reserved   ; Language-specific reserved names (avoid name collision)
   '(False None True and as assert break class continue def del

--- a/src/core2rust.rkt
+++ b/src/core2rust.rkt
@@ -8,7 +8,10 @@
 
 (define rust-supported
   (supported-list
-    (invert-op-proc (curry set-member? '(tgamma lgamma fdim erf erfc remainder)))
+    (invert-op-proc
+      (curry set-member?
+            '(tgamma lgamma fdim erf erfc remainder
+              array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(SQRT1_2)))
     (curry equal? 'binary64)
     (curry equal? 'nearestEven)))

--- a/src/core2rust.rkt
+++ b/src/core2rust.rkt
@@ -14,7 +14,8 @@
               array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(SQRT1_2)))
     (curry equal? 'binary64)
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define rust-reserved   ; Language-specific reserved names (avoid name collisions)
   '(as break const continue crate else enum extern false fn for if impl in let loop match

--- a/src/core2scala.rkt
+++ b/src/core2scala.rkt
@@ -21,7 +21,8 @@
             array dim size ref for for* tensor tensor*))
     (curry set-member? '(TRUE FALSE))
     (curry set-member? '(binary32 binary64 binary128 binary256))        
-    (curry equal? 'nearestEven)))
+    (curry equal? 'nearestEven)
+    #f))
 
 (define scala-reserved  ; Language-specific reserved names (avoid name collisions)
   '(and abstract case catch class def do else extends false

--- a/src/core2scala.rkt
+++ b/src/core2scala.rkt
@@ -17,7 +17,8 @@
     (curry set-member?
           '(+ - * / sqrt sin cos tan asin acos atan exp log fma      ;; pow has partial support
             < > <= >= == != and or not
-            if let let* digits !))   ;; benchmarks with if statements break with --mixed-precision flag
+            if let let* digits !    ;; benchmarks with if statements break with --mixed-precision flag
+            array dim size ref for for* tensor tensor*))
     (curry set-member? '(TRUE FALSE))
     (curry set-member? '(binary32 binary64 binary128 binary256))        
     (curry equal? 'nearestEven)))

--- a/src/core2smtlib2.rkt
+++ b/src/core2smtlib2.rkt
@@ -15,7 +15,8 @@
           let let* array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(LOG2E LOG10E M_1_PI M_2_PI M_2_SQRTPI)))
     (curry set-member? '(binary32 binary64))
-    ieee754-rounding-modes))
+    ieee754-rounding-modes
+    #f))
 
 (define smt-reserved  ; Language-specific reserved names (avoid name collisions)
   '(BINARY DECIMAL HEXADECIMAL NUMERAL STRING

--- a/src/core2smtlib2.rkt
+++ b/src/core2smtlib2.rkt
@@ -12,7 +12,7 @@
         '(remainder fmax fmin trunc round nearbyint
           < > <= >= == and or not
           isinf isnan isnormal signbit
-          let let*)))
+          let let* array dim size ref for for* tensor tensor*)))
     (invert-const-proc (curry set-member? '(LOG2E LOG10E M_1_PI M_2_PI M_2_SQRTPI)))
     (curry set-member? '(binary32 binary64))
     ieee754-rounding-modes))

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -7,7 +7,10 @@
 (define sollya-supported 
   (supported-list
     (invert-op-proc 
-      (curry set-member? '(isnormal tgamma lgamma remainder fmod round cbrt atan2 signbit)))
+      (curry set-member?
+            '(isnormal tgamma lgamma remainder fmod round
+              cbrt atan2 signbit array dim size ref
+              for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary32 binary64 binary80 integer))
     ieee754-rounding-modes))

--- a/src/core2sollya.rkt
+++ b/src/core2sollya.rkt
@@ -13,7 +13,8 @@
               for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary32 binary64 binary80 integer))
-    ieee754-rounding-modes))
+    ieee754-rounding-modes
+    #f))
 
 (define *sollya-warnings* (make-parameter #t))
 

--- a/src/core2tex.rkt
+++ b/src/core2tex.rkt
@@ -5,7 +5,7 @@
 
 (define tex-supported 
   (supported-list
-    (negate (curry set-member? '(while while*)))
+    (negate (curry set-member? '(while while* array dim size ref for for* tensor tensor*)))
     (curry set-member? '(PI E INFINITY NAN TRUE FALSE))
     (const #t)
     ieee754-rounding-modes))

--- a/src/core2tex.rkt
+++ b/src/core2tex.rkt
@@ -8,7 +8,8 @@
     (negate (curry set-member? '(while while* array dim size ref for for* tensor tensor*)))
     (curry set-member? '(PI E INFINITY NAN TRUE FALSE))
     (const #t)
-    ieee754-rounding-modes))
+    ieee754-rounding-modes
+    #f))
 
 ;;
 ;;  This compiler is adapted from Herbie

--- a/src/core2wls.rkt
+++ b/src/core2wls.rkt
@@ -9,7 +9,7 @@
 
 (define wls-supported
   (supported-list
-    fpcore-ops
+    (invert-op-proc (curry set-member? '(array size ref dim for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary64 real integer))
     (curry set-member? '(nearestEven))))

--- a/src/core2wls.rkt
+++ b/src/core2wls.rkt
@@ -12,7 +12,8 @@
     (invert-op-proc (curry set-member? '(array size ref dim for for* tensor tensor*)))
     fpcore-consts
     (curry set-member? '(binary64 real integer))
-    (curry set-member? '(nearestEven))))
+    (curry set-member? '(nearestEven))
+    #f))
 
 (define wls-reserved '(E PI))  ; Language-specific reserved names (avoid name collisions)
 

--- a/src/core2wls.rkt
+++ b/src/core2wls.rkt
@@ -14,7 +14,7 @@
     (curry set-member? '(binary64 real integer))
     (curry set-member? '(nearestEven))))
 
-(define wls-reserved '(E Pi))  ; Language-specific reserved names (avoid name collisions)
+(define wls-reserved '(E PI))  ; Language-specific reserved names (avoid name collisions)
 
 (define (fix-name name)
   (string-join

--- a/src/supported.rkt
+++ b/src/supported.rkt
@@ -87,7 +87,8 @@
    (set)]
   [(visit-op_ vtor op args)
    (set-add (visit-op_/reduce vtor op args) op)]
-  [reduce (curry apply set-union)])
+  [reduce
+   (λ (sets) (apply set-union (set) sets))])
 
 (define/contract (operators-in core)
   (-> fpcore? (set/c symbol?))
@@ -101,7 +102,7 @@
 ; (-> expr? (set/c symbol?)
   [(visit-terminal_ vtor x) (set)]
   [(visit-constant vtor x) (set x)]
-  [reduce (curry apply set-union)])
+  [reduce (λ (sets) (apply set-union (set) sets))])
 
 (define/contract (constants-in core)
   (-> fpcore? (set/c symbol?))
@@ -129,9 +130,12 @@
                       (lambda (k v1 v2) (set-union v1 v2))) args))])
 
 (define (property-values-variables prop-hash vars)
-  (for/fold ([prop-hash* prop-hash]) ([var vars] #:when (list? var))
-    (match-define (list '! props ... name) var)
-    (property-hash-add prop-hash* props)))
+  (for/fold ([prop-hash* prop-hash]) ([var vars])
+    (match var
+      [(list '! props ... name)
+       (property-hash-add prop-hash* props)]
+      [_
+       prop-hash*])))
 
 (define/contract (property-values core)
   (-> fpcore? property-hash?)


### PR DESCRIPTION
This PR addresses why #115 is failing. Tensor benchmarks should not be valid in any of our current benchmarks. Also fixes Julia in CI due to OS version changes in GitHub Actions.