### PR TITLE
Initial Launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 www
 library/Real.scala
+fpbench-compiled/
 *~
 *.dep
 *.zo

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,16 @@ setup:
 testsetup:
 	raco make infra/*.rkt
 
+distribute:
+	mkdir -p fpbench-compiled/
+	cp README.md fpbench-compiled/
+	cp LICENSE.txt fpbench-compiled/
+	cp logo.png fpbench-compiled/
+	raco exe -o fpbench --orig-exe --embed-dlls --vv main.rkt
+	[ ! -f fpbench.exe ] || (raco distribute fpbench-compiled fpbench.exe && rm fpbench.exe)
+	[ ! -f fpbench.app ] || (raco distribute fpbench-compiled fpbench.app && rm fpbench.app)
+	[ ! -f fpbench ] || (raco distribute fpbench-compiled fpbench && rm fpbench)
+
 ##### Testing
 
 c-sanity:

--- a/main.rkt
+++ b/main.rkt
@@ -1,4 +1,7 @@
-#lang racket/base
+#lang racket
+
+(require 
+  "export.rkt")
 
 (require
  "src/canonicalizer.rkt"
@@ -71,9 +74,14 @@
   "infra/filter.rkt"
   "infra/gen-expr.rkt"
   ))
-
 (module+ main
-  (eprintf "FPBench provides with two tools:\n")
-  (eprintf "  export.rkt - export FPCore to other languages\n")
-  (eprintf "  transform.rkt - apply program transformations to FPCores\n")
-  (eprintf "Run those tools with --help for more information.\n"))
+  (cond 
+    [(= 0 (vector-length (current-command-line-arguments)))
+      (eprintf "FPBench provides with two tools:\n")
+      (eprintf "  export.rkt - export FPCore to other languages\n")
+      (eprintf "  transform.rkt - apply program transformations to FPCores\n")
+      (eprintf "Run those tools with --help for more information.\n")]
+    [(equal? (vector-ref (current-command-line-arguments) 0) "export")
+      (export-main (vector-drop (current-command-line-arguments) 1) (current-input-port) (current-output-port))]
+
+    ))

--- a/main.rkt
+++ b/main.rkt
@@ -1,6 +1,8 @@
 #lang racket
 
 (require 
+  "transform.rkt"
+  "evaluate.rkt"
   "export.rkt")
 
 (require
@@ -74,14 +76,20 @@
   "infra/filter.rkt"
   "infra/gen-expr.rkt"
   ))
+
 (module+ main
   (cond 
     [(= 0 (vector-length (current-command-line-arguments)))
       (eprintf "FPBench provides with two tools:\n")
-      (eprintf "  export.rkt - export FPCore to other languages\n")
-      (eprintf "  transform.rkt - apply program transformations to FPCores\n")
+      (eprintf "  export/compile - export FPCore to other languages\n")
+      (eprintf "  transform - apply program transformations to FPCores\n")
       (eprintf "Run those tools with --help for more information.\n")]
     [(equal? (vector-ref (current-command-line-arguments) 0) "export")
       (export-main (vector-drop (current-command-line-arguments) 1) (current-input-port) (current-output-port))]
-
+    [(equal? (vector-ref (current-command-line-arguments) 0) "compile")
+      (export-main (vector-drop (current-command-line-arguments) 1) (current-input-port) (current-output-port))]
+    [(equal? (vector-ref (current-command-line-arguments) 0) "transform")
+      (transform-main (vector-drop (current-command-line-arguments) 1) (current-input-port) (current-output-port))]
+    [(equal? (vector-ref (current-command-line-arguments) 0) "evaluate")
+      (evaluate-main (vector-drop (current-command-line-arguments) 1) (current-input-port) (current-output-port))]
     ))


### PR DESCRIPTION
This PR adds a `make` target (`make distribute`) for creating an executable for FPBench.

The resulting executable behaves as specified in the design document for tools that already exist (features such as filtering etc. are still unimplemented). 
The notable exceptions are the inclusion of the subcommand `export`, which is an alias for `compile`; and the inclusion of the subcommand `evaluate`, which runs the evaluate tool.


This mechanism has only been tested through WSL. 
The make script is directly ripped from Herbie's `make distribute` target.