### PR TITLE
Fix underscore escaping for variables in Tex output

### DIFF
--- a/src/core2tex.rkt
+++ b/src/core2tex.rkt
@@ -73,7 +73,7 @@
   [('lambda)  "\\lambda"]
   [('lambda1) "\\lambda_1"]
   [('lambda2) "\\lambda_2"]
-  [(_) (symbol->string expr)])
+  [(_) (string-replace (symbol->string expr) "_" "\\_")])
 
 (define/match (constant->tex expr)
   [('PI)            "\\pi"]


### PR DESCRIPTION
This pull requests fixes the issues with underscores in Tex output for FPCore expressions.
See related [issue](https://github.com/herbie-fp/herbie/issues/668) in [herbie](github.com/herbie-fp/herbie).