### PR TITLE
ci: speedup julia test & setup ci for pr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ env:
   CAKEML_BIN: '../cache/cakeml'
   DAISY_VERSION: 'b483303f3914106173902669855d371ff73bf568'
   DAISY_BASE: '../cache/daisy'
-  JULIA_VERSION: '1.8'
+  # latest stable version
+  JULIA_VERSION: '1'
   
 jobs:
   unit:   # package setup, Racket unit testing
@@ -591,7 +592,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: '1'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -621,7 +622,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: '1'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -651,7 +652,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: '1'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto
@@ -681,7 +682,7 @@ jobs:
       - name: "Install Julia"
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: '1'
 
       - name: "Install as Racket package"
         run: raco pkg install --auto

--- a/infra/test-core2julia.rkt
+++ b/infra/test-core2julia.rkt
@@ -39,7 +39,7 @@
     (parameterize ([current-error-port err-p])
       (values
         (with-output-to-string
-          (λ () (system (format "julia ~a ~a" exec-name (string-join in " ")))))
+          (λ () (system (format "julia --compile=min -O0 -g0 --history-file=no -- ~a ~a" exec-name (string-join in " ")))))
         (get-output-string err-p))))
   (define out*
     (cond


### PR DESCRIPTION
The startup and pre-compilation costs of julia are high,
so for simple computations you can skip the pre-compilation and optimization.

```
Baseline:
    santity:    88s
    benchmarks: 604s
    binary32:   724s
    binary64:   721s

Pr:
    santity:    29s
    benchmarks: 216s
    binary32:   269s
    binary64:   301s
```
