### PR TITLE
Fix build status badge and typo in `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: "Tensor examples"
         run: make tensor-test
 
-  c:    # C langugae
+  c:    # C language
     name: "C Tests"
     runs-on: ubuntu-latest
     needs: [ 'unit' ]
@@ -105,7 +105,7 @@ jobs:
       - name: "C test"
         run: make c-test
 
-  java:   # Java langugae
+  java:   # Java language
     name: "Java Tests"
     runs-on: ubuntu-latest
     needs: [ 'unit' ]
@@ -202,7 +202,7 @@ jobs:
       - name: "Rust test"
         run: make rust-test
 
-  js:    # JavaScript langugae
+  js:    # JavaScript language
     name: "JavaScript Tests"
     runs-on: ubuntu-latest
     needs: [ 'unit' ]
@@ -239,7 +239,7 @@ jobs:
       - name: "JS test"
         run: make js-test
 
-  sollya:    # Sollya langugae
+  sollya:    # Sollya language
     name: "Sollya Tests"
     runs-on: ubuntu-latest
     needs: [ 'unit' ]
@@ -267,7 +267,7 @@ jobs:
       - name: "Sollya test"
         run: make sollya-test
 
-  fptaylor:   # FPTaylor langugae
+  fptaylor:   # FPTaylor language
     name: "FPTaylor Tests"
     runs-on: ubuntu-latest
     needs: [ 'unit' ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FPBench provides benchmarks, compilers, and standards for the floating-point research community. 
 
-[![Build Status](https://github.com/FPBench/FPBench/workflows/build/badge.svg?branch=master)](https://github.com/FPBench/FPBench/actions)
+[![Build Status](https://github.com/FPBench/FPBench/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/FPBench/FPBench/actions)
 
 Setup
 -----


### PR DESCRIPTION
This PR fixes the build status badge and fixes the typo of language in the `test.yml` file.