### PR TITLE
Fixing exponential-size Fortran output programs for nested min/max operators 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fpbench-compiled/
 *.dep
 *.zo
 *.swp
+fmin_fmax_functions.mod

--- a/src/core2fortran03.rkt
+++ b/src/core2fortran03.rkt
@@ -122,23 +122,22 @@
           arg)  ; TODO: warn unfaithful
       arg))
 
-(define (fortran-header type)
-  (format
-   "~a function fmin(x, y)
-    ~a, intent (in) :: x
-    ~a, intent (in) :: y
+(define (fortran-header)
+   "real function fmin(x, y)
+    real, intent (in) :: x
+    real, intent (in) :: y
     fmin = merge(y, merge(x, min(x, y), y /= y), x /= x)
 end function\n
-~a function fmax(x, y)
-    ~a, intent (in) :: x
-    ~a, intent (in) :: y
+real function fmax(x, y)
+    real, intent (in) :: x
+    real, intent (in) :: y
     fmax = merge(y, merge(x, max(x, y), y /= y), x /= x)
-end function\n\n" type type type type type type))
+end function\n\n")
 
 (define (program->fortran name args arg-ctxs body ret ctx used-vars)
   (define type (type->fortran (ctx-lookup-prop ctx ':precision)))
   (define declared-in (sort (remove* args used-vars) string<?))
-  (define header (fortran-header type))
+  (define header (fortran-header))
   (format "~a~a function ~a(~a)\n~a~a~a    ~a = ~a\nend function\n"  header type name
           (string-join args ", ")
           (apply string-append

--- a/src/core2fortran03.rkt
+++ b/src/core2fortran03.rkt
@@ -124,7 +124,7 @@
 
 (define (fortran-header)
   (format
-   "module min_max_functions
+   "module fmin_fmax_functions
     implicit none
     private
     public fmax

--- a/src/core2fortran03.rkt
+++ b/src/core2fortran03.rkt
@@ -128,7 +128,7 @@
     ~a, intent (in) :: x
     ~a, intent (in) :: y
     fmin = merge(y, merge(x, min(x, y), y /= y), x /= x)
-end function
+end function\n
 ~a function fmax(x, y)
     ~a, intent (in) :: x
     ~a, intent (in) :: y

--- a/src/core2fortran03.rkt
+++ b/src/core2fortran03.rkt
@@ -123,22 +123,74 @@
       arg))
 
 (define (fortran-header)
-   "real function fmin(x, y)
-    real, intent (in) :: x
-    real, intent (in) :: y
-    fmin = merge(y, merge(x, min(x, y), y /= y), x /= x)
-end function\n
-real function fmax(x, y)
-    real, intent (in) :: x
-    real, intent (in) :: y
-    fmax = merge(y, merge(x, max(x, y), y /= y), x /= x)
-end function\n\n")
+  (format
+   "module min_max_functions
+    implicit none
+    private
+    public fmax
+    public fmin
+
+    interface fmax
+        module procedure fmax88
+        module procedure fmax44
+        module procedure fmax84
+        module procedure fmax48
+    end interface
+    interface fmin
+        module procedure fmin88
+        module procedure fmin44
+        module procedure fmin84
+        module procedure fmin48
+    end interface
+contains
+    real(8) function fmax88(x, y) result (res)
+        real(8), intent (in) :: x
+        real(8), intent (in) :: y
+        res = merge(y, merge(x, max(x, y), y /= y), x /= x)
+    end function
+    real(4) function fmax44(x, y) result (res)
+        real(4), intent (in) :: x
+        real(4), intent (in) :: y
+        res = merge(y, merge(x, max(x, y), y /= y), x /= x)
+    end function
+    real(8) function fmax84(x, y) result(res)
+        real(8), intent (in) :: x
+        real(4), intent (in) :: y
+        res = merge(dble(y), merge(x, max(x, dble(y)), y /= y), x /= x)
+    end function
+    real(8) function fmax48(x, y) result(res)
+        real(4), intent (in) :: x
+        real(8), intent (in) :: y
+        res = merge(y, merge(dble(x), max(dble(x), y), y /= y), x /= x)
+    end function
+    real(8) function fmin88(x, y) result (res)
+        real(8), intent (in) :: x
+        real(8), intent (in) :: y
+        res = merge(y, merge(x, min(x, y), y /= y), x /= x)
+    end function
+    real(4) function fmin44(x, y) result (res)
+        real(4), intent (in) :: x
+        real(4), intent (in) :: y
+        res = merge(y, merge(x, min(x, y), y /= y), x /= x)
+    end function
+    real(8) function fmin84(x, y) result(res)
+        real(8), intent (in) :: x
+        real(4), intent (in) :: y
+        res = merge(dble(y), merge(x, min(x, dble(y)), y /= y), x /= x)
+    end function
+    real(8) function fmin48(x, y) result(res)
+        real(4), intent (in) :: x
+        real(8), intent (in) :: y
+        res = merge(y, merge(dble(x), min(dble(x), y), y /= y), x /= x)
+    end function
+end module\n\n"))
 
 (define (program->fortran name args arg-ctxs body ret ctx used-vars)
   (define type (type->fortran (ctx-lookup-prop ctx ':precision)))
   (define declared-in (sort (remove* args used-vars) string<?))
   (define header (fortran-header))
-  (format "~a~a function ~a(~a)\n~a~a~a    ~a = ~a\nend function\n"  header type name
+  (format "~a~a function ~a(~a)\nuse fmin_fmax_functions\n~a~a~a    ~a = ~a\nend function\n"
+          header type name
           (string-join args ", ")
           (apply string-append
             (for/list ([arg args] [ctx arg-ctxs])


### PR DESCRIPTION
Same as #134, Fortran also can output exponential-size programs with nested `fmin` and `fmax` operators.
This PR fixes this by introducing helper functions.