### PR TITLE
Fix the first link & rename page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -13,7 +13,7 @@
     </a>
     <p>Browse the standard benchmark suite</p>
     <ul>
-      <li><a href="index.html">Home</a></li>
+      <li><a href="https://fpbench.github.io/fpbench">Home</a></li>
       <li><a href="benchmarks.html">Benchmarks</a></li>
       <li><a href="https://github.com/FPBench/FPBench/blob/main/tools.md">Compilers</a></li>
       <li><a href="spec/index.html">Standards</a></li>


### PR DESCRIPTION
This will make `https://fpbench.github.io/fpbench` the official website for the FPBench benchmark suite.