### PR TITLE
Upgrade `ocaml/setup-ocaml` to v3 and OCaml itself to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,9 +282,9 @@ jobs:
           version: '8.2'
       
       - name: "Install OCaml"
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: '4.04.2'
+          ocaml-compiler: 5
 
       - name: "Install Packages"
         run: |
@@ -430,9 +430,9 @@ jobs:
           version: '8.2'
 
       - name: "Install OCaml"
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: '4.08.1'
+          ocaml-compiler: 5
 
       - name: "Install Packages"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,7 +284,7 @@ jobs:
       - name: "Install OCaml"
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: '4.04.2'
 
       - name: "Install Packages"
         run: |


### PR DESCRIPTION
Our CI stopped working because it seems like the old version of `setup-ocaml` no longer runs. I took the chance to upgrade our OCaml version too.